### PR TITLE
[bug 794095] Add settings/celery-settings views

### DIFF
--- a/fjord/base/admin.py
+++ b/fjord/base/admin.py
@@ -1,0 +1,52 @@
+import re
+
+from django import http
+from django.contrib import admin
+from django.shortcuts import render
+from django.views import debug
+
+import celery.conf
+import jinja2
+
+
+def settings_view(request):
+    """Admin view that displays the django settings."""
+    settings = debug.get_safe_settings()
+    sorted_settings = [{'key': key, 'value': settings[key]}
+                       for key in sorted(settings.keys())]
+
+    return render(request, 'admin/settings_view.html', {
+            'settings': sorted_settings,
+            'title': 'App Settings'
+            })
+
+
+admin.site.register_view('settings', settings_view,
+                         'Settings - App Settings')
+
+
+def celery_settings_view(request):
+    """Admin view that displays the celery configuration."""
+    capital = re.compile('^[A-Z]')
+    settings = [key for key in dir(celery.conf) if capital.match(key)]
+    sorted_settings = [
+        {'key': key,
+         'value': ('*****' if 'password' in key.lower()
+                   else getattr(celery.conf, key))}
+        for key in sorted(settings)]
+
+    return render(request, 'admin/settings_view.html', {
+            'settings': sorted_settings,
+            'title': 'Celery Settings'
+            })
+
+
+admin.site.register_view('celery', celery_settings_view,
+                         'Settings - Celery Settings')
+
+
+def env_view(request):
+    """Admin view that displays the wsgi env."""
+    return http.HttpResponse(u'<pre>%s</pre>' % (jinja2.escape(request)))
+
+admin.site.register_view('env', env_view, 'WSGI Environment')

--- a/fjord/base/templates/admin/settings_view.html
+++ b/fjord/base/templates/admin/settings_view.html
@@ -1,0 +1,20 @@
+{% extends "admin/base_site.html" %}
+
+{% block content_title %}
+<h1>Settings - {{ title }}</h1>
+{% endblock %}
+
+{% block content %}
+<table id="settings">
+  <tbody>
+    {% for setting in settings %}
+      <tr>
+        <th id="{{ setting.key|slugify }}">
+          {{ setting.key }} <a href="#{{ setting.key|slugify }}">¶</a>
+        </th>
+        <td>{{ setting.value|pprint }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
- add app settings view so we can see server configuration
- add celery settings view so we can see celery configuration
- add wsgi env view so we can see the wsgi environment (though we haven't
  needed this, yet)

Note: The template is a Django template, so it uses Django template stuff.
Also, I lifted this from Kitsune so it's pretty much the same code that's
in Kitsune with some very minor cleanup.

Tiny r?
