### PR TITLE
Tweak dashboard template for mobile

### DIFF
--- a/fjord/analytics/templates/analytics/mobile/dashboard.html
+++ b/fjord/analytics/templates/analytics/mobile/dashboard.html
@@ -1,1 +1,5 @@
-<p>Mobile dashboard.</p>
+{% extends "mobile/base.html" %}
+
+{% block content %}
+  <p>{{ _('Dashboard is not available on mobile devices, yet.') }}</p>
+{% endblock %}

--- a/fjord/base/templates/mobile/base.html
+++ b/fjord/base/templates/mobile/base.html
@@ -33,15 +33,6 @@
       </header>
     {% endblock site_header %}
 
-    {% if settings.SHOW_STAGE_NOTICE %}
-      {{ css('stage') }}
-      <div class="stage-banner">
-        <div class="close-button">X</div>
-        This is a dev/staging site. The production site is
-        <a href="http://input.mozilla.org">here</a>.
-      </div>
-    {% endif %}
-
     <div class="content">
       {% block content %}{% endblock %}
     </div>


### PR DESCRIPTION
- add a better stub that uses the mobile base
- nix the dev-banner for mobile templates --- it's too big and hard
  to get to go away. we'll do something different later.

r?
