### PR TITLE
Fix login

### DIFF
--- a/fjord/analytics/static/js/dashboard.js
+++ b/fjord/analytics/static/js/dashboard.js
@@ -1,4 +1,12 @@
 $(function() {
+    var $histogram = $('.graph .histogram');
+
+    // If the histogram isn't on the page, then we're probably looking
+    // at the es_down template and none of this will work.
+    if ($histogram.length === 0) {
+        return;
+    }
+
     // General widgets.
     // Expandos
     $('.expando').hide();
@@ -77,7 +85,6 @@ $(function() {
 
 
     // Draw histogram in the middle column.
-    var $histogram = $('.graph .histogram');
     var data = $histogram.data('histogram');
     colors = {
         'happy': '#72BF3E',


### PR DESCRIPTION
If there's no index or ES is down, then you see the es_down page. That
page has no histogram, so the dashboard.js code was erroring out which
prevented the browserid stuff from setting up and thus you couldn't
log in.

This fixes that.

r?
