### PR TITLE
moving update logic into commander compatible script for use with chief

### DIFF
--- a/bin/update/update.py
+++ b/bin/update/update.py
@@ -1,0 +1,119 @@
+"""
+Deploys fjord for input.mozilla.org
+
+Requires commander_ which is installed on the systems that need it.
+
+.. _commander: https://github.com/oremj/commander
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+import commander_settings as settings
+
+
+@task
+def update_code(ctx, tag):
+    """Update the code to a specific git reference (tag/sha/etc)."""
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local('git fetch')
+        ctx.local('git checkout -f %s' % tag)
+        ctx.local('git submodule sync')
+        ctx.local('git submodule update --init --recursive')
+
+
+@task
+def update_locales(ctx):
+    """Update a locale directory from SVN.
+
+    Assumes localizations 1) exist, 2) are in SVN, 3) are in SRC_DIR/locale and
+    4) have a compile-mo.sh script. This should all be pretty standard, but
+    change it if you need to.
+
+    """
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
+        ctx.local('svn up')
+        ctx.local('./compile-mo.sh .')
+
+@task
+def update_assets(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        
+        ctx.local("python2.6 manage.py collectstatic --noinput")
+        ctx.local("")
+
+@task
+def update_db(ctx):
+    """Update the database schema, if necessary.
+
+    Uses schematic by default. Change to south if you need to.
+
+    """
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("python2.6 manage.py migrate --all")
+
+@task
+def checkin_changes(ctx):
+    """Use the local, IT-written deploy script to check in changes."""
+    ctx.local(settings.DEPLOY_SCRIPT)
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy_app(ctx):
+    """Call the remote update script to push changes to webheads."""
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+    ctx.remote('/bin/touch %s' % settings.REMOTE_WSGI)
+
+
+@hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def update_celery(ctx):
+    """Update and restart Celery."""
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+
+
+@task
+def update_info(ctx):
+    """Write info about the current state to a publicly visible file."""
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local('date')
+        ctx.local('git branch')
+        ctx.local('git log -3')
+        ctx.local('git status')
+        ctx.local('git submodule status')
+        ctx.local('python2.6 ./vendor/src/schematic/schematic -v migrations/')
+        with ctx.lcd('locale'):
+            ctx.local('svn info')
+            ctx.local('svn status')
+
+        ctx.local('git rev-parse HEAD > media/revision.txt')
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    """Update code to pick up changes to this file."""
+    update_code(ref)
+    update_info()
+
+@task
+def update(ctx):
+    update_assets()
+    update_locales()
+    update_db()
+
+
+@task
+def deploy(ctx):
+    checkin_changes()
+    deploy_app()
+    update_celery()
+
+
+@task
+def update_site(ctx, tag):
+    """Update the app to prep for deployment."""
+    pre_update(tag)
+    update()


### PR DESCRIPTION
Chief requires a different script. I've copied the logic from bin/update_site.py for a first cut.

Please merge this, then I'll deploy to stage and make sure it works.

Once it's happy we'll backport to stage and update the cron there to just call Chief every time
