### PR TITLE
[bug 855671] Fix Windows version parsing for Firefox 3.6

### DIFF
--- a/fjord/base/browsers.py
+++ b/fjord/base/browsers.py
@@ -88,6 +88,15 @@ def parse_ua(ua):
     while platform in ['X11', 'Ubuntu', 'U']:
         platform = platform_parts.pop(0)
 
+    if platform == 'Windows':
+        # Firefox 3.6 has the Windows version later in the parts. So
+        # skim the parts to find a version that's in WINDOWS_VERSION.
+        # If we don't find anything, just leave things as is.
+        possible_platforms = [p for p in platform_parts
+                              if p in WINDOWS_VERSION]
+        if possible_platforms:
+            platform = possible_platforms[0]
+
     if platform in WINDOWS_VERSION.keys():
         platform, platform_version = WINDOWS_VERSION[platform]
     elif platform.startswith('Linux'):

--- a/fjord/base/tests/user_agent_data.json
+++ b/fjord/base/tests/user_agent_data.json
@@ -126,5 +126,21 @@
       "platform": "OS X",
       "platform_version": "10.8",
       "mobile": false
+    },
+    {
+      "user_agent": "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.9.2.17) Gecko/20110420 Firefox/3.6.17 GTB7.1 ( .NET CLR 3.5.30729; .NET4.0C) FBSMTWB",
+      "browser": "Firefox",
+      "browser_version": "3.6.17",
+      "platform": "Windows",
+      "platform_version": "Vista",
+      "mobile": false
+    },
+    {
+      "user_agent":  "Mozilla/5.0 (Windows; U; Windows NT 5.1; es-ES; rv:1.9.2.11) Gecko/20101012 Firefox/3.6.11 (.NET CLR 3.5.30729)",
+      "browser": "Firefox",
+      "browser_version": "3.6.11",
+      "platform": "Windows",
+      "platform_version": "XP",
+      "mobile": false
     }
-  ]
+]

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -81,11 +81,23 @@ class TestFeedback(TestCase):
         """Using non-Firefox browser lands you on download-firefox page."""
         # TODO: This test might need to change when the router starts routing.
         url = reverse('feedback')
-        ua = ('Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 '
-              '(KHTML, like Gecko) Chrome/24.0.1312.68 Safari/537.17')
 
-        r = self.client.get(url, HTTP_USER_AGENT=ua)
-        self.assertRedirects(r, reverse('download-firefox'))
+        for ua in (
+            ('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; '
+             'Trident/5.0)'),
+            ('Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 '
+             '(KHTML, like Gecko) Chrome/24.0.1312.68 Safari/537.17'),
+            ('Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus '
+             'Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 '
+             'Mobile Safari/534.30'),
+            ('Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Xoom Build/IMM76) '
+             'AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 '
+             'Safari/534.30'),
+            ('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.22 (KHTML, like '
+             'Gecko) Chrome/25.0.1364.97 Safari/537.22')):
+
+            r = self.client.get(url, HTTP_USER_AGENT=ua)
+            self.assertRedirects(r, reverse('download-firefox'))
 
     def test_email_collection(self):
         """If the user enters an email and checks the box, collect the email."""


### PR DESCRIPTION
Bug 855671 covers two problems with UserAgent parsing. This fixes
one of them and adds a test for the second, but I wasn't able
to reproduce the second, so I'm puzzled.

I'm going to land this and then see if the other one (IntegrityError: (1048, "Column 'browser' cannot be null")) happens again.

r?
