### PR TITLE
[bug 862625] Add happy/sad redirects

### DIFF
--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -8,6 +8,18 @@ from fjord.feedback import models
 from fjord.feedback.views import _get_prodchan
 
 
+class TestRedirectFeedback(TestCase):
+    client_class = LocalizingClient
+
+    def test_happy_redirect(self):
+        r = self.client.get(reverse('happy-redirect'))
+        self.assertRedirects(r, reverse('feedback') + '#happy')
+
+    def test_sad_redirect(self):
+        r = self.client.get(reverse('sad-redirect'))
+        self.assertRedirects(r, reverse('feedback') + '#sad')
+
+
 class TestFeedback(TestCase):
     client_class = LocalizingClient
 

--- a/fjord/feedback/urls.py
+++ b/fjord/feedback/urls.py
@@ -1,9 +1,14 @@
 from django.conf.urls.defaults import patterns, url
 
 
-urlpatterns = patterns('fjord.feedback.views',
+urlpatterns = patterns(
+    'fjord.feedback.views',
+
     url(r'^feedback(?:/(?P<formname>[\w\._-]+))?/?$', 'feedback_router',
         name='feedback'),
     url(r'^thanks/$', 'thanks', name='thanks'),
     url(r'^downloadfirefox/$', 'download_firefox', name='download-firefox'),
+
+    url(r'^happy/?$', 'happy_redirect', name='happy-redirect'),
+    url(r'^sad/?$', 'sad_redirect', name='sad-redirect'),
 )

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -14,6 +14,18 @@ from fjord.feedback.forms import ResponseForm
 from fjord.feedback import models
 
 
+def happy_redirect(request):
+    # TODO: Remove this when the addon gets fixed and is pointing to
+    # the correct urls.
+    return HttpResponseRedirect(reverse('feedback') + '#happy')
+
+
+def sad_redirect(request):
+    # TODO: Remove this when the addon gets fixed and is pointing to
+    # the correct urls.
+    return HttpResponseRedirect(reverse('feedback') + '#sad')
+
+
 @mobile_template('feedback/{mobile/}download_firefox.html')
 def download_firefox(request, template):
     return render(request, template)


### PR DESCRIPTION
This adds redirects for handling /happy and /sad which are urls that
are being used somewhere. As soon as those urls are fixed we can
remove these redirects. This is covered in bug #862844.

r?
