### PR TITLE
[bug 866449] Add mobile template for response

### DIFF
--- a/fjord/analytics/templates/analytics/mobile/response.html
+++ b/fjord/analytics/templates/analytics/mobile/response.html
@@ -1,0 +1,45 @@
+{% extends "mobile/base.html" %}
+
+{% block site_css %}
+  {{ css('dashboard') }}
+{% endblock %}
+
+{# Remove site header. #}
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<div class="col full">
+  <div class="block feedback">
+    <h2>{{ _('Response id: {id}')|f(id=response.id) }}</h2>
+
+    <ul>
+      <li class="opinion">
+        {% if response.happy %}
+        <span class="sprite happy">{{ _('Happy') }}</span>
+        {% else %}
+        <span class="sprite sad">{{ _('Sad') }}</span>
+        {% endif %}
+        <p>
+          {{ response.description }}
+        </p>
+        <ul class="meta">
+{# Note: This next line says it's -0800/PST, but the server time is
+   Pacific and "celebrates" daylight savings so it's a villainous lie
+   for all datetimes in PDT. #}
+          <li>
+            {% set response_date = convert_date_string(response_created) %}
+            <a href="{{ url('dashboard')|urlparams(date_start=response_date) }}">
+              <time datetime="{{ response_created }}-08:00" title="{{ response_created }} PST">
+                {{ response_created|naturaltime }}
+              </time>
+            </a>
+          </li>
+          <li><a href="{{ url('dashboard')|urlparams(platform=response.platform) }}">{{ response.platform }}</a></li>
+          <li><a href="{{ url('dashboard')|urlparams(locale=response.locale) }}">{{ response.locale|locale_name }}</a></li>
+          <li><a href="{{ url('response_view', responseid=response.id) }}">{{ _('Permalink') }}</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/fjord/analytics/tests/test_views.py
+++ b/fjord/analytics/tests/test_views.py
@@ -299,3 +299,15 @@ class TestResponseview(ElasticTestCase):
         eq_(200, r.status_code)
         self.assertTemplateUsed(r, 'analytics/response.html')
         assert str(resp.description) in r.content
+
+    def test_response_view_mobile(self):
+        """Test response mobile view doesn't die"""
+        resp = response(happy=True, description=u'the best!', save=True)
+
+        self.refresh()
+
+        r = self.client.get(reverse('response_view', args=(resp.id,)),
+                            {'mobile': 1})
+        eq_(200, r.status_code)
+        self.assertTemplateUsed(r, 'analytics/mobile/response.html')
+        assert str(resp.description) in r.content

--- a/fjord/base/static/css/fjord.less
+++ b/fjord/base/static/css/fjord.less
@@ -217,6 +217,10 @@ header {
     width: 54%;
   }
 
+  &.full {
+    width: 100%;
+  }
+
   .block {
     background: white;
     padding: 15px;


### PR DESCRIPTION
It's not super pretty, but it's functional and reuses a lot of stuff.

This handles the use case where someone puts links to responses in an email that should get looked at and someone using a mobile device tries to open up the link.

r?
