### PR TITLE
Fix version filter

### DIFF
--- a/fjord/analytics/tests/test_views.py
+++ b/fjord/analytics/tests/test_views.py
@@ -215,6 +215,23 @@ class TestDashboardView(ElasticTestCase):
         pq = PyQuery(r.content)
         eq_(len(pq('li.opinion')), 0)
 
+    def test_browser_version_noop(self):
+        """browser_version has no effect if browser isn't set"""
+        url = reverse('dashboard')
+
+        # Filter on product and version--both filters affect the
+        # results
+        r = self.client.get(
+            url, {'browser': 'Firefox', 'browser_version': '18.0.0'})
+        pq = PyQuery(r.content)
+        eq_(len(pq('li.opinion')), 0)
+
+        # Filter on version--filter has no effect on results
+        r = self.client.get(
+            url, {'browser_version': '18.0.0'})
+        pq = PyQuery(r.content)
+        eq_(len(pq('li.opinion')), 7)
+
     def test_text_search(self):
         url = reverse('dashboard')
         # Text search

--- a/fjord/analytics/views.py
+++ b/fjord/analytics/views.py
@@ -264,9 +264,12 @@ def dashboard(request, template):
     if search_product:
         f &= F(browser=search_product)
         current_search['browser'] = search_product
-    if search_version:
-        f &= F(browser_version=search_version)
-        current_search['browser_version'] = search_version
+
+        if search_version:
+            # Note: We only filter on version if we're filtering on
+            # product.
+            f &= F(browser_version=search_version)
+            current_search['browser_version'] = search_version
 
     if search_date_start is None and search_date_end is None:
         selected = '7d'


### PR DESCRIPTION
If the user isn't filtering on product, then we should ignore the version
filter.

The better fix would also nix it from the url, but that's a lot harder
and requires some non-trivial rewiring so I'm going to do this for now
and if that's not sufficient then figure out a different fix.

r?
