### PR TITLE
Add ES version to search admin and status cmd

### DIFF
--- a/fjord/base/util.py
+++ b/fjord/base/util.py
@@ -75,3 +75,30 @@ def smart_bool(s, fallback=False):
 def epoch_milliseconds(d):
     """Convert a datetime to a number of milliseconds since the epoch."""
     return time.mktime(d.timetuple()) * 1000
+
+
+class FakeLogger(object):
+    """Fake logger that we can pretend is a Python Logger
+
+    Why? Well, because Django has logging settings that prevent me
+    from setting up a logger here that uses the stdout that the Django
+    BaseCommand has. At some point p while fiddling with it, I
+    figured, 'screw it--I'll just write my own' and did.
+
+    The minor ramification is that this isn't a complete
+    implementation so if it's missing stuff, we'll have to add it.
+    """
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+    def _out(self, level, msg, *args):
+        msg = msg % args
+        self.stdout.write('%s %-8s: %s\n' % (
+                time.strftime('%H:%M:%S'), level, msg))
+
+    def info(self, msg, *args):
+        self._out('INFO', msg, *args)
+
+    def error(self, msg, *args):
+        self._out('ERROR', msg, *args)

--- a/fjord/search/index.py
+++ b/fjord/search/index.py
@@ -5,6 +5,7 @@ from itertools import islice
 from django.conf import settings
 from django.db import reset_queries
 
+import requests
 from elasticutils.contrib.django import get_es, S, MappingType
 from pyelasticsearch.exceptions import (ConnectionError, Timeout,
                                         ElasticHttpNotFoundError)
@@ -386,12 +387,18 @@ def es_delete_cmd(index):
 
 
 @requires_good_connection
-def es_status_cmd(checkindex=False):
+def es_status_cmd(checkindex=False, log=log):
     """Show ElasticSearch index status."""
     log.info('Settings:')
     log.info('  ES_URLS               : %s', settings.ES_URLS)
     log.info('  ES_INDEX_PREFIX       : %s', settings.ES_INDEX_PREFIX)
     log.info('  ES_INDEXES            : %s', settings.ES_INDEXES)
+
+    try:
+        es_deets = requests.get(settings.ES_URLS[0]).json()
+        log.info('  Elasticsearch version : %s', es_deets['version']['number'])
+    except requests.exceptions.RequestException:
+        log.info('  Could not connect to Elasticsearch')
 
     log.info('Index (%s) stats:', get_index())
 

--- a/fjord/search/management/commands/esstatus.py
+++ b/fjord/search/management/commands/esstatus.py
@@ -1,7 +1,6 @@
-import logging
-
 from django.core.management.base import BaseCommand
 
+from fjord.base.util import FakeLogger
 from fjord.search.index import es_status_cmd
 
 
@@ -9,5 +8,4 @@ class Command(BaseCommand):
     help = 'Shows elastic search index status.'
 
     def handle(self, *args, **options):
-        logging.basicConfig(level=logging.INFO)
-        es_status_cmd()
+        es_status_cmd(log=FakeLogger(self.stdout))

--- a/fjord/search/templates/admin/search_admin_view.html
+++ b/fjord/search/templates/admin/search_admin_view.html
@@ -58,7 +58,7 @@
   {% endif %}
 
   <section>
-    <h1>Settings</h1>
+    <h1>Settings and details</h1>
     <p>
       Settings at the time this page was loaded:
     </p>
@@ -66,6 +66,7 @@
       <tr><th>ES_URLS</th><td>{{ settings.ES_URLS }}</td></tr>
       <tr><th>ES_INDEX_PREFIX</th><td>{{ settings.ES_INDEX_PREFIX }}</td></tr>
       <tr><th>ES_INDEXES</th><td>{{ settings.ES_INDEXES }}</td></tr>
+      <tr><th>Elasticsearch version</th><td>{{ es_deets.version.number }}</td></tr>
     </table>
   </section>
 


### PR DESCRIPTION
It's almost exactly the same set of changes I made to Kitsune just now.

Adds the Elasticsearch version to the admin and the estatus command output.

Tiny r?
