### PR TITLE
Fix POST mutability problem

### DIFF
--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -175,8 +175,8 @@ def android_about_feedback(request):
     # uses the old `_type` variable from old Input. Tweak the data to do
     # what FfA means, not what it says.
 
-    # Make `request.GET` mutable.
-    request.GET = request.GET.copy()
+    # Make `request.POST` mutable.
+    request.POST = request.POST.copy()
 
     # For _type, 1 is happy, 2 is sad, 3 is idea. We convert that so
     # that _type = 1 -> happy = 1 and everything else -> happy = 0.


### PR DESCRIPTION
Originally, the code would make GET mutable and then change the value in the GET QueryDict. I changed it to change the value in the POST QueryDict with the other data because otherwise it wasn't setting happy right.

However, I screwed up and didn't make the POST QueryDict mutable. I'm not entirely sure how that passed all the testing. My best guess is that request.GET/request.POST are different in the tests than they are than on a server. And for some reason, you can add a `foo = 0` to an imutable POST QueryDict, but can't add a `foo = 1`. Since I was only testing the sad case (that's the only one you can test with about:feedback), that's the only case I was triggering.

Totally puzzling.

Tiny r?
