### PR TITLE
Nix the DEV_LANGUAGES thing

### DIFF
--- a/docs/maintain.rst
+++ b/docs/maintain.rst
@@ -38,7 +38,7 @@ Adding a new locale
 ===================
 
 To add a new locale so that ``https://input.mozilla.org/%NEWLOCALE%`` works
-and so that people can submit feedback:
+and so that people can see the site in that language and submit feedback:
 
 1. In your local repository, run::
 
@@ -70,25 +70,3 @@ and so that people can submit feedback:
 
 5. Commit the changes to ``fjord/settings/base.py`` and product details stuff
    to git.
-
-
-.. Note::
-
-   To test this in a local instance, you need to have::
-
-       DEV_LANGUAGES = PROD_LANGUAGES
-
-   in your ``fjord/settings/local.py``. Otherwise ``DEV_LANGUAGES`` is
-   the list of locales in ``locales/``.
-
-   After making that change, you can go to
-   ``https://127.0.0.1:8000/%NEWLOCALE%`` and it won't redirect to
-   ``https://127.0.0.1:8000/en-US/%NEWLOCALE%``.
-
-
-.. Note::
-
-   https://input-dev.allizom.org/ uses ``DEV_LANGUAGES``, so any changes
-   you make to ``PROD_LANGUAGES`` won't affect the -dev environment.
-
-   You'll have to do the testing on the staging environment.

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -155,6 +155,8 @@ PROD_LANGUAGES = [
     'zu'
 ]
 
+DEV_LANGUAGES = PROD_LANGUAGES
+
 INSTALLED_APPS = get_apps(
     exclude=(
         'compressor',


### PR DESCRIPTION
It's annoying as all hell to have DEV_LANGUAGES and PROD_LANGUAGES where
one is generated and the other is set in stone and you see different
things depending on whether you're in a dev environment or not. It
essentially means you could be donig some work, all tests pass, you
push it to master and then it dies on stage or prod because those
are different.

This nixes that and reduces the amount of misery in our lives.
Now there is only PROD_LANGUAGES.

r?
