### PR TITLE
Add second data migration to fix responses

### DIFF
--- a/fjord/feedback/migrations/0009_backfill_again.py
+++ b/fjord/feedback/migrations/0009_backfill_again.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from south.v2 import DataMigration
+
+# Does a second pass on the data migration to catch the responses that
+# were being created when the migration was happening and thus didn't
+# get updated.
+
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        working_set = orm.Response.objects.filter(product='')
+
+        print '{0} responses to update.'.format(len(working_set))
+
+        for resp in working_set:
+            # This replicates the logic in Response.infer_product.
+            if resp.platform == u'Unknown':
+                resp.product = u'Unknown'
+                resp.channel = u'Unknown'
+                resp.version = u'Unknown'
+
+            else:
+                if resp.platform == u'FirefoxOS':
+                    resp.product = u'Firefox OS'
+                elif resp.platform == u'Android':
+                    resp.product = u'Firefox for Android'
+                else:
+                    resp.product = u'Firefox'
+
+                resp.channel = u'stable'
+                resp.version = resp.browser_version
+
+            resp.save()
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'prodchan': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']
+    symmetrical = True


### PR DESCRIPTION
The 0008 data migration takes a long time to run. It missed a bunch
of responses which I think were created after the sql query was
run, so the ids weren't included in the batch.

We could fix the 0008 data migration, go back and run it again, but
it's way easier to just write a new data migration to patch the
situation.

To test:
1. `./manage.py migrate feedback` -- That'll move you to 0009. It'll say something like "0 responses updated.'
2. `./manage.py migrate feedback 0008` -- That'll go back to 0008. It's a no-op.
3. Use mysql client to change `product=''` for some number of responses in your db.
4. Run `./manage.py migrate feedback` -- That'll move you to 0009 and it should update a bunch of responses.

r?
