### PR TITLE
Tweak serializer save code to be more correct

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -222,13 +222,14 @@ class ResponseSerializer(serializers.Serializer):
 
         return opinion
 
-    def save(self, *args, **kwargs):
-        saved_obj = super(ResponseSerializer, self).save(*args, **kwargs)
-        if saved_obj.email:
-            opinion_email = ResponseEmail(
-                email=saved_obj.email,
-                opinion=saved_obj
-            )
-            opinion_email.save()
+    def save_object(self, obj, **kwargs):
+        obj.save(**kwargs)
 
-        return saved_obj
+        if obj.email:
+            opinion_email = ResponseEmail(
+                email=obj.email,
+                opinion=obj
+            )
+            opinion_email.save(**kwargs)
+
+        return obj


### PR DESCRIPTION
This switches the save code to be in save_object() rather than
save() which is more correct in regards to how django-rest-framework
expects you to do things.

minor r?
