### PR TITLE
Move settings.VALID_PRODUCTS to PRODUCTS in feedback

### DIFF
--- a/docs/maintain.rst
+++ b/docs/maintain.rst
@@ -43,7 +43,7 @@ Adding a new product choice to the API
 
 To add a new product choice to the API, do this:
 
-1. Add the new value to ``VALID_PRODUCTS`` in ``fjord/settings/base.py``
+1. Add the new value to ``PRODUCTS`` in ``fjord/feedback/config.py``
 2. Add the value to the docs at ``docs/api.rst``
 
 

--- a/fjord/feedback/config.py
+++ b/fjord/feedback/config.py
@@ -1,0 +1,8 @@
+# List of valid products accepted by the Input API
+# Note: When you change this, please change the API docs, too!
+PRODUCTS = [
+    # (Value to store, Human readable)
+    (u'Firefox OS', u'Firefox OS'),
+    (u'Firefox for Android', u'Firefox for Android'),
+    (u'Firefox', u'Firefox'),
+]

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -9,6 +9,7 @@ from tower import ugettext_lazy as _
 
 from fjord.base.models import ModelBase
 from fjord.base.util import smart_truncate
+from fjord.feedback import config
 from fjord.search.index import (
     register_mapping_type, FjordMappingType,
     boolean_type, date_type, integer_type, keyword_type, text_type)
@@ -179,8 +180,7 @@ class ResponseSerializer(serializers.Serializer):
     # browser since those don't make sense.
 
     # product, channel, version, locale, platform
-    product = serializers.ChoiceField(choices=settings.VALID_PRODUCTS,
-                                      required=True)
+    product = serializers.ChoiceField(choices=config.PRODUCTS, required=True)
     channel = serializers.CharField(max_length=30, required=False, default=u'')
     version = serializers.CharField(max_length=30, required=False, default=u'')
     locale = serializers.CharField(max_length=8, required=False, default=u'')

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -13,15 +13,6 @@ PROJECT_MODULE = 'fjord'
 # Defines the views served for root URLs.
 ROOT_URLCONF = '%s.urls' % PROJECT_MODULE
 
-# List of valid products accepted by the Input API
-# Note: When you change this, please change the API docs, too!
-VALID_PRODUCTS = [
-    # (Value to store, Human readable)
-    (u'Firefox OS', u'Firefox OS'),
-    (u'Firefox for Android', u'Firefox for Android'),
-    (u'Firefox', u'Firefox'),
-]
-
 # This is the list of languages that are active for non-DEV
 # environments. Add languages here to allow users to see the site in
 # that locale and additionally submit feedback in that locale.


### PR DESCRIPTION
This changes things so that valid options for the Input feedback
web forms and API will all be located in fjord/feedback/config.py
to make for easier maintenance.

Quick r?
