### PR TITLE
[bug 917779] Give Firefox OS some space

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,7 +84,7 @@ Posting feedback
         String. The name of the operating system/platform the product
         is running on.
 
-        Examples: ``"OS X"``, ``"Windows 8"``, ``"FirefoxOS"``,
+        Examples: ``"OS X"``, ``"Windows 8"``, ``"Firefox OS"``,
         ``"Android"``, ``"Linux"``
 
     **locale**

--- a/fjord/base/browsers.py
+++ b/fjord/base/browsers.py
@@ -130,21 +130,29 @@ def parse_ua(ua):
     # platform."  It is the only platform to do this, so we can still
     # uniquely identify it.
     if platform == 'Mobile':
-        platform = 'FirefoxOS'
+        platform = 'Firefox OS'
+        browser = 'Firefox OS'
 
-        # Now try to infer the FirefoxOS version from the Gecko
-        # version. If we can, then we set the browser,
-        # browser_version and platform_version.
+        # Set versions to UNKNOWN. This handles the case where the
+        # version of Gecko doesn't line up with a Firefox OS product
+        # release.
+        browser_version = UNKNOWN
+        platform_version = UNKNOWN
+
+        # Now try to infer the Firefox OS version from the Gecko
+        # version. If we can, then we set the browser_version and
+        # platform_version.
         for part in browser_parts:
             if 'Gecko' in part and len(part) > 1:
                 fxos_version = GECKO_TO_FIREFOXOS_VERSION.get(part[1])
                 if fxos_version is not None:
-                    browser = "Firefox OS"
                     browser_version = fxos_version
                     platform_version = fxos_version
+                    break
 
-    # Make sure browser_version is at least x.y.z
-    if browser_version != UNKNOWN:
+    # Make sure browser_version is at least x.y.z for non-Firefox OS
+    # browsers.
+    if browser != 'Firefox OS' and browser_version != UNKNOWN:
         while browser_version.count('.') < 2:
             browser_version += '.0'
 

--- a/fjord/base/tests/user_agent_data.json
+++ b/fjord/base/tests/user_agent_data.json
@@ -106,9 +106,33 @@
    {
        "user_agent": "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0",
        "browser": "Firefox OS",
-       "browser_version": "1.0.0",
-       "platform": "FirefoxOS",
+       "browser_version": "1.0",
+       "platform": "Firefox OS",
        "platform_version": "1.0",
+       "mobile": true
+   },
+   {
+       "user_agent": "Mozilla/5.0 (Mobile; rv:18.1) Gecko/18.1 Firefox/18.1",
+       "browser": "Firefox OS",
+       "browser_version": "1.1",
+       "platform": "Firefox OS",
+       "platform_version": "1.1",
+       "mobile": true
+   },
+   {
+       "user_agent": "Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0",
+       "browser": "Firefox OS",
+       "browser_version": "1.2",
+       "platform": "Firefox OS",
+       "platform_version": "1.2",
+       "mobile": true
+   },
+   {
+       "user_agent": "Mozilla/5.0 (Mobile; rv:22.0) Gecko/22.0 Firefox/22.0",
+       "browser": "Firefox OS",
+       "browser_version": "",
+       "platform": "Firefox OS",
+       "platform_version": "",
        "mobile": true
    },
    {

--- a/fjord/feedback/migrations/0013_convert_firefoxos_to_firefox_os.py
+++ b/fjord/feedback/migrations/0013_convert_firefoxos_to_firefox_os.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        # Convert "FirefoxOS" -> "Firefox OS"
+        print 'updated', (orm.Response.objects
+                          .filter(platform=u'FirefoxOS')
+                          .update(platform=u'Firefox OS'))
+
+    def backwards(self, orm):
+        # Convert "Firefox OS" -> "FirefoxOS"
+        print 'updated', (orm.Response.objects
+                          .filter(platform=u'Firefox OS')
+                          .update(platform=u'FirefoxOS'))
+
+    models = {
+        'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'prodchan': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']
+    symmetrical = True

--- a/fjord/feedback/migrations/0014_convert_version_to_unknown.py
+++ b/fjord/feedback/migrations/0014_convert_version_to_unknown.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import re
+
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+GECKO_TO_FIREFOXOS_VERSION = {
+    '18.0': '1.0',
+    '18.1': '1.1',
+    '26.0': '1.2'
+}
+
+def get_browser_parts(ua):
+    """Return browser parts portion of user agent"""
+    match = re.match(r'^Mozilla[^(]+\(([^)]+)\) (.+)', ua)
+
+    if match is None:
+        return []
+
+    # The rest is space seperated A/B pairs. Pull out both sides of
+    # the slash.
+    # Result: [['Gecko', '14.0'], ['Firefox', '14.0.2']]
+    browser_parts = [p.split('/') for p in match.group(2).split(' ')]
+
+    return browser_parts
+
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        # This is just like 0012 except that it wipes the
+        # browser_version and platform_version columns first, then
+        # tries to infer the Firefox OS version. The result of this is
+        # that if we can't infer the Firefox OS version, then the
+        # browser_version and platform_version columns become
+        # "Unknown" rather than continue to be the Gecko version which
+        # is confusing and wrong.
+        working_set = orm.Response.objects.filter(product=u'Firefox OS')
+
+        for resp in working_set:
+            resp.version = u''
+            resp.browser_version = u''
+            resp.platform_version = u''
+
+            parts = get_browser_parts(resp.user_agent)
+            for part in parts:
+                if 'Gecko' in part and len(part) > 1:
+                    fxos_version = GECKO_TO_FIREFOXOS_VERSION.get(part[1])
+                    if fxos_version is not None:
+                        resp.version = fxos_version
+                        resp.browser_version = fxos_version
+                        resp.platform_version = fxos_version
+                        break
+
+            resp.save()
+
+        print '0014: {0} fixed'.format(working_set.count())
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'prodchan': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']
+    symmetrical = True

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -91,7 +91,7 @@ class Response(ModelBase):
 
     @classmethod
     def infer_product(cls, platform):
-        if platform == u'FirefoxOS':
+        if platform == u'Firefox OS':
             return u'Firefox OS'
 
         elif platform == u'Android':

--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -33,7 +33,7 @@ class TestFeedbackAPI(TestCase):
             'product': u'Firefox OS',
             'channel': u'stable',
             'version': u'1.1',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
             'email': 'foo@example.com'
         }
@@ -63,7 +63,7 @@ class TestFeedbackAPI(TestCase):
             'product': u'Firefox OS',
             'channel': u'stable',
             'version': u'1.1',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
             'email': 'foo@example'
         }
@@ -80,7 +80,7 @@ class TestFeedbackAPI(TestCase):
             'product': u'Firefox OS',
             'channel': u'stable',
             'version': u'1.1',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
         }
 
@@ -96,7 +96,7 @@ class TestFeedbackAPI(TestCase):
             'description': u'Great!',
             'product': u'Firefox OS',
             'version': u'1.1',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
         }
 
@@ -115,7 +115,7 @@ class TestFeedbackAPI(TestCase):
     #     data = {
     #         'description': u'Great!',
     #         'version': u'1.1',
-    #         'platform': u'FirefoxOS',
+    #         'platform': u'Firefox OS',
     #         'locale': 'en-US',
     #     }
     #
@@ -129,7 +129,7 @@ class TestFeedbackAPI(TestCase):
             'product': u'Firefox OS',
             'channel': u'stable',
             'version': u'1.1',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
         }
 
@@ -143,7 +143,7 @@ class TestFeedbackAPI(TestCase):
             'channel': u'stable',
             'version': u'1.1',
             'description': u'Great!',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
         }
 
@@ -158,7 +158,7 @@ class TestFeedbackAPI(TestCase):
             'version': u'1.1',
             'description': u'Great!',
             'product': u'Nurse Kitty',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
         }
 
@@ -184,7 +184,7 @@ class TestFeedbackAPI(TestCase):
             'product': u'Firefox OS',
             'channel': u'stable',
             'version': u'1.1',
-            'platform': u'FirefoxOS',
+            'platform': u'Firefox OS',
             'locale': 'en-US',
         }
 

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -80,8 +80,8 @@ class TestFeedback(TestCase):
         eq_(u'stable', feedback.channel)
         eq_(u'14.0.1', feedback.version)
 
-    def test_valid_happy_firefoxos(self):
-        """Happy feedback from FirefoxOS works"""
+    def test_valid_happy_firefox_os(self):
+        """Happy feedback from Firefox OS works"""
         amount = models.Response.objects.count()
 
         url = reverse('feedback')
@@ -105,7 +105,9 @@ class TestFeedback(TestCase):
 
         # Make sure product and inferred version are correct
         eq_(u'Firefox OS', feedback.product)
-        eq_(u'1.0.0', feedback.version)
+        eq_(u'Firefox OS', feedback.platform)
+        eq_(u'1.0', feedback.version)
+        eq_(u'1.0', feedback.browser_version)
 
     def test_invalid_form(self):
         """Submitting a bad form should return an error and not change pages."""

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -135,7 +135,7 @@ def _get_prodchan(request):
 
     if meta.platform == 'Android':
         platform = 'android'
-    elif meta.platform == 'FirefoxOS':
+    elif meta.platform == 'Firefox OS':
         platform = 'fxos'
     elif product == 'firefox':
         platform = 'desktop'


### PR DESCRIPTION
- change "FirefoxOS" to "Firefox OS" across the project
- data migration to convert "FirefoxOS" to "Firefox OS" in platform
  field
- fix browser detection to not add .0 to end of Firefox OS versions
- add tests for all Firefox OS user agents plus one non-sensical one
- data migration to convert non-sensical Firefox OS versions to ''

To test:
1. run the tests with `FORCE_DB=1`
2. run the migrations
3. reindex
4. click through the dashboard and make sure the facet values and data look ok

r?
