### PR TITLE
Fix form router for Firefox OS form

### DIFF
--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -80,34 +80,14 @@ class TestFeedback(TestCase):
         eq_(u'stable', feedback.channel)
         eq_(u'14.0.1', feedback.version)
 
-    def test_valid_happy_firefox_os(self):
-        """Happy feedback from Firefox OS works"""
-        amount = models.Response.objects.count()
-
+    def test_firefox_os_view(self):
+        """Firefox OS returns correct view"""
         url = reverse('feedback')
         ua = 'Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0'
 
-        data = {
-            'happy': 1,
-            'description': u'Firefox rocks!',
-            'url': u'http://mozilla.org/'
-        }
+        r = self.client.get(url, HTTP_USER_AGENT=ua)
 
-        r = self.client.post(url, data, HTTP_USER_AGENT=ua)
-
-        self.assertRedirects(r, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
-
-        feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'Firefox rocks!', feedback.description)
-        eq_(u'http://mozilla.org/', feedback.url)
-        eq_(True, feedback.happy)
-
-        # Make sure product and inferred version are correct
-        eq_(u'Firefox OS', feedback.product)
-        eq_(u'Firefox OS', feedback.platform)
-        eq_(u'1.0', feedback.version)
-        eq_(u'1.0', feedback.browser_version)
+        self.assertTemplateUsed(r, 'feedback/mobile/fxos_feedback.html')
 
     def test_invalid_form(self):
         """Submitting a bad form should return an error and not change pages."""

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -268,7 +268,9 @@ def feedback_router(request, formname=None, *args, **kwargs):
         view = android_about_feedback
 
     if view is None:
-        if request.BROWSER.mobile:
+        if request.BROWSER.browser == 'Firefox OS':
+            view = firefox_os_stable_feedback
+        elif request.BROWSER.mobile:
             view = mobile_stable_feedback
         else:
             view = desktop_stable_feedback


### PR DESCRIPTION
This fixes the form router so if you go to http://localhost:8000/feedback/ it now goes to the right form.

Additionally, this redoes the view test so it correctly tests that the right template was used. Since it submits to the API, the API tests cover that side of things.

r?
