### PR TITLE
Tweak email verification

### DIFF
--- a/fjord/feedback/static/js/mobile/fxos_feedback.js
+++ b/fjord/feedback/static/js/mobile/fxos_feedback.js
@@ -72,11 +72,13 @@ function init() {
     if ($('#email-ok').is(':checked')) {
       email = $.trim($('#email-input').val());
 
-      // this should be close enough to what django is doing that we
-      // can catch issues client-side
-      if (!email.match(/^[a-zA-Z0-9._\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,6}$/)) {
-        $('#email-error').show();
-        return;
+      if (email !== '') {
+        // this should be close enough to what django is doing that we
+        // can catch issues client-side
+        if (!email.match(/^[a-zA-Z0-9._\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,6}$/)) {
+          $('#email-error').show();
+          return;
+        }
       }
 
       // in case it was showing, we hide it again
@@ -100,7 +102,7 @@ function init() {
 
     // FIXME - figure out Firefox OS version from Gecko version in UA
 
-    if ($('#email-ok:checked').val()) {
+    if ($('#email-ok:checked').val() && email !== '') {
       data.email = $('#email-input').val();
     }
 


### PR DESCRIPTION
If the email input value is just whitespace or empty, then we should let
the form submit. This makes it a little more inline with the label which
says "(optional)".

Quick r?
