### PR TITLE
[bug #926892] Nix manufacturer from Firefox OS form

### DIFF
--- a/fjord/feedback/config.py
+++ b/fjord/feedback/config.py
@@ -28,11 +28,9 @@ FIREFOX_OS_COUNTRIES = [
     (u'CS', 'Montenegro', _lazy('Montenegro')),
 ]
 
-# List of (value, display name) for Firefox OS devices that
-# have been released.
-# The value is a :: separated string for (manufacturer, device).
+# List of Firefox OS devices that have been released.
 FIREFOX_OS_DEVICES = [
-    (u'ZTE::Open', u'ZTE Open'),
-    (u'Alcatel::OneTouch Fire', u'Alcatel OneTouch Fire'),
-    (u'Geeksphone::', u'Geeksphone'),
+    u'ZTE Open',
+    u'Alcatel OneTouch Fire',
+    u'Geeksphone',
 ]

--- a/fjord/feedback/static/js/mobile/fxos_feedback.js
+++ b/fjord/feedback/static/js/mobile/fxos_feedback.js
@@ -66,7 +66,7 @@ function init() {
   });
 
   $('button.complete').on('click', function() {
-    var data, device, email, jqxhr, numCards;
+    var data, email, jqxhr, numCards;
 
     // verify email address
     if ($('#email-ok').is(':checked')) {
@@ -87,8 +87,6 @@ function init() {
       storageAddItem('email', $('#email-input').val());
     }
 
-    device = $('#device select').val().split('::');
-
     data = {
       'happy': $('#happy').val(),
       'description': $('#description').val(),
@@ -96,8 +94,7 @@ function init() {
       'platform': 'Firefox OS',
       'locale': $('#locale').val(),
       'country': $('#country select').val(),
-      'manufacturer': device[0],
-      'device': device[1]
+      'device': $('#device select').val()
     };
 
     // FIXME - figure out Firefox OS version from Gecko version in UA

--- a/fjord/feedback/templates/feedback/mobile/fxos_feedback.html
+++ b/fjord/feedback/templates/feedback/mobile/fxos_feedback.html
@@ -70,8 +70,8 @@
         {{ _('What Firefox OS device are you using?') }}
       </p>
       <select name="device">
-        {% for value, display in devices %}
-          <option value="{{ value }}">{{ display }}</option>
+        {% for value in devices %}
+          <option value="{{ value }}">{{ value }}</option>
         {% endfor %}
         <option value="">{{ _('Other') }}</option>
       </select>


### PR DESCRIPTION
This tweaks the code so that we no longer split the device name into
manufacturer and device but instead stick the whole thing in the device
column. This lines up with what the feedback form in settings in Firefox
OS will do (bug #851189).

Quick r?
