### PR TITLE
[bug 929664] Truncate description at 10000

### DIFF
--- a/fjord/feedback/migrations/0017_truncate_description.py
+++ b/fjord/feedback/migrations/0017_truncate_description.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+TRUNCATE_LENGTH = 10000
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        affected_count = 0
+
+        working_set = orm.Response.objects.all()
+
+        for resp in working_set:
+            if len(resp.description) > TRUNCATE_LENGTH:
+                resp.description = resp.description[:TRUNCATE_LENGTH]
+                resp.save()
+                affected_count += 1
+
+        print 'Truncated {0} descriptions'.format(affected_count)
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'prodchan': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']
+    symmetrical = True

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -16,6 +16,12 @@ from fjord.search.index import (
 from fjord.search.tasks import register_live_index
 
 
+# This defines the number of characters the description can have.  We
+# do this in code rather than in the db since it makes it easier to
+# tweak the value.
+TRUNCATE_LENGTH = 10000
+
+
 @register_live_index
 class Response(ModelBase):
     """Basic feedback response
@@ -76,6 +82,10 @@ class Response(ModelBase):
 
     def __repr__(self):
         return self.__unicode__().encode('ascii', 'ignore')
+
+    def save(self, *args, **kwargs):
+        self.description = self.description[:TRUNCATE_LENGTH]
+        super(Response, self).save(*args, **kwargs)
 
     @property
     def sentiment(self):

--- a/fjord/feedback/tests/test_models.py
+++ b/fjord/feedback/tests/test_models.py
@@ -1,0 +1,13 @@
+from nose.tools import eq_
+
+from fjord.base.tests import TestCase
+from fjord.feedback.tests import response
+
+
+class TestResponseModel(TestCase):
+    def test_description_truncate_on_save(self):
+        # Extra 10 characters get lopped off on save.
+        resp = response(description=('a' * 10010))
+        resp.save()
+
+        eq_(resp.description, 'a' * 10000)


### PR DESCRIPTION
This truncates the description at 10,000 characters. I'm doing it in
code-space rather than database-space because we're probably going to
tweak the value a bit as time goes on and it's easier to do that in
code.

Quick r?
