### PR TITLE
[bug 918959] Strip that whitespace!

### DIFF
--- a/fjord/feedback/migrations/0018_strip_whitespace.py
+++ b/fjord/feedback/migrations/0018_strip_whitespace.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+    def forwards(self, orm):
+        affected_count = 0
+
+        working_set = orm.Response.objects.all()
+
+        for resp in working_set:
+            resp_stripped = resp.description.strip()
+            if resp.description != resp_stripped:
+                resp.description = resp_stripped
+                resp.save()
+                affected_count += 1
+
+        print 'Stripped {0} descriptions'.format(affected_count)
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'prodchan': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']
+    symmetrical = True

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -84,7 +84,7 @@ class Response(ModelBase):
         return self.__unicode__().encode('ascii', 'ignore')
 
     def save(self, *args, **kwargs):
-        self.description = self.description[:TRUNCATE_LENGTH]
+        self.description = self.description.strip()[:TRUNCATE_LENGTH]
         super(Response, self).save(*args, **kwargs)
 
     @property

--- a/fjord/feedback/tests/test_models.py
+++ b/fjord/feedback/tests/test_models.py
@@ -11,3 +11,10 @@ class TestResponseModel(TestCase):
         resp.save()
 
         eq_(resp.description, 'a' * 10000)
+
+    def test_description_strip_on_save(self):
+        # Nix leading and trailing whitespace.
+        resp = response(description=u'   \n\tou812\t\n   ')
+        resp.save()
+
+        eq_(resp.description, u'ou812')


### PR DESCRIPTION
This tweaks Response.save() to strip description whitespace before
saving to the db. We can do this in other places, but given that all
those other places feed in through here, it makes sense to do it here.

This also includes a data migration to strip all the existing responses.

quick r?
