### PR TITLE
[bug 934721] Move privacy text up

### DIFF
--- a/fjord/base/static/css/feedback.less
+++ b/fjord/base/static/css/feedback.less
@@ -126,7 +126,7 @@ article {
       position: relative;
 
       > div:not(:first-child) {
-        margin-top: 35px;
+        margin-top: 30px;
       }
 
       label {
@@ -239,8 +239,7 @@ input[type=text], input[type=url], textarea {
 }
 
 .privacy {
-  margin-top: .5em;
-  font-size: 12px;
+  font-size: 14px;
   color: #5c4b00;
 
   span {

--- a/fjord/feedback/templates/feedback/feedback-form.html
+++ b/fjord/feedback/templates/feedback/feedback-form.html
@@ -31,16 +31,17 @@
             {% endif %}
           </label>
           <p>{{ form.description }}</p>
-          <div id="{{ type }}-description-counter" class="characters-remaining"></div>
           {{ form.description.errors }}
         </div>
 
-        <div>
-          <label for="url">
-            {{ _('If your feedback is related to a website, you can include it here.') }}
-          </label>
-          <p>{{ form.url }}</p>
-          {{ form.url.errors }}
+        <div class="privacy">
+          <span>
+            {% trans %}
+              To protect your privacy, please ensure that no
+              personally identifiable information is included in
+              your feedback.
+            {% endtrans %}
+          </span>
         </div>
 
         {% if type == 'sad' %}
@@ -55,6 +56,14 @@
             {% endtrans %}
           </div>
         {% endif %}
+
+        <div>
+          <label for="url">
+            {{ _('If your feedback is related to a website, you can include it here.') }}
+          </label>
+          <p>{{ form.url }}</p>
+          {{ form.url.errors }}
+        </div>
 
         <label class="email-ok">
           <p>
@@ -84,17 +93,6 @@
           {% endtrans %}
         </p>
 
-        <div class="privacy-wrapper">
-          <p class="privacy">
-            <span>
-              {% trans %}
-              To protect your privacy, please ensure that no
-              personally identifiable information is included in
-              your feedback.
-              {% endtrans %}
-            </span>
-          </p>
-        </div>
       </div>
 
       {{ form.errors['__all__'] }}


### PR DESCRIPTION
- move privacy text up to just under description textarea
- remove some extraneous html containers
- nix character counter--that was never implemented
- tighten up some of the vertical whitespace

r?
