### PR TITLE
[bug 936625] Add country to serializer

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,6 +92,15 @@ Posting feedback
 
         Examples: ``"en-US"``, ``"fr"``, ``"de"``
 
+    **country**
+        String. The country of origin for the device.
+
+        Examples: ``"Peru"``, ``"Mexico"``
+
+        .. Note::
+
+           This is probably only relevant to Firefox OS phones.
+
     **manufacturer**
         String. The manufacturer of the device the product is running
         on.

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -198,6 +198,7 @@ class ResponseSerializer(serializers.Serializer):
     version = serializers.CharField(max_length=30, required=False, default=u'')
     locale = serializers.CharField(max_length=8, required=False, default=u'')
     platform = serializers.CharField(max_length=30, required=False, default=u'')
+    country = serializers.CharField(max_length=4, required=False, default=u'')
 
     # device information
     manufacturer = serializers.CharField(required=False, default=u'')
@@ -229,7 +230,8 @@ class ResponseSerializer(serializers.Serializer):
             platform=attrs['platform'].strip(),
             locale=attrs['locale'].strip(),
             manufacturer=attrs['manufacturer'].strip(),
-            device=attrs['device'].strip()
+            device=attrs['device'].strip(),
+            country=attrs['country'].strip()
         )
 
         # If there is an email address, stash it on this instance so


### PR DESCRIPTION
This adds the country to the serializer so it gets captured by the API
and stored in the db.

This adds a test that wouldn't have found this problem, but is a good
test to have anyhow since it makes sure all the pieces line up and that
we're testing a "maximal" API call.

Quick r?
