### PR TITLE
Quell migration spam during tests

### DIFF
--- a/fjord/feedback/migrations/0009_backfill_again.py
+++ b/fjord/feedback/migrations/0009_backfill_again.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import os
 from south.v2 import DataMigration
+from django.conf import settings
 
 # Does a second pass on the data migration to catch the responses that
 # were being created when the migration was happening and thus didn't
@@ -10,7 +12,8 @@ class Migration(DataMigration):
     def forwards(self, orm):
         working_set = orm.Response.objects.filter(product='')
 
-        print '0009: {0} responses to update.'.format(len(working_set))
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), '{0} responses to update'.format(len(working_set))
 
         for resp in working_set:
             # This replicates the logic in Response.infer_product.

--- a/fjord/feedback/migrations/0010_convert_unknown_to_empty.py
+++ b/fjord/feedback/migrations/0010_convert_unknown_to_empty.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
+import os
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
 
 class Migration(DataMigration):
     def forwards(self, orm):
@@ -11,7 +10,10 @@ class Migration(DataMigration):
 
         for col in ('platform', 'product', 'channel', 'browser',
                     'browser_version'):
-            print '0010:', col, orm.Response.objects.filter(**{col: u'Unknown'}).update(**{col: u''})
+
+            ret = orm.Response.objects.filter(**{col: u'Unknown'}).update(**{col: u''})
+            if not getattr(settings, 'TEST'):
+                print os.path.basename(__file__), col, ret
 
     def backwards(self, orm):
         # NB: This is technically not a perfect backwards migration since
@@ -19,7 +21,9 @@ class Migration(DataMigration):
 
         for col in ('platform', 'product', 'channel', 'browser',
                     'browser_version'):
-            print '0010:', col, orm.Response.objects.filter(**{col: u''}).update(**{col: u'Unknown'})
+            ret = orm.Response.objects.filter(**{col: u''}).update(**{col: u'Unknown'})
+            if not getattr(settings, 'TEST'):
+                print os.path.basename(__file__), col, ret
 
     models = {
         'feedback.response': {

--- a/fjord/feedback/migrations/0011_convert_residual_unknown_to_empty.py
+++ b/fjord/feedback/migrations/0011_convert_residual_unknown_to_empty.py
@@ -1,20 +1,23 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
+import os
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
 
 class Migration(DataMigration):
     def forwards(self, orm):
         # Change "Unknown" to "" in version column
 
-        print '0011: version updated', orm.Response.objects.filter(version=u'Unknown').update(version=u'')
+        ret = orm.Response.objects.filter(version=u'Unknown').update(version=u'')
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), ret
 
     def backwards(self, orm):
         # NB: This is technically not a perfect backwards migration since
         # we don't have the original values for those columns.
 
-        print '0011: version updated', orm.Response.objects.filter(version=u'').update(version=u'Unknown')
+        ret = orm.Response.objects.filter(version=u'').update(version=u'Unknown')
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), ret
 
     models = {
         'feedback.response': {

--- a/fjord/feedback/migrations/0012_fix_firefoxos_version.py
+++ b/fjord/feedback/migrations/0012_fix_firefoxos_version.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
+import os
 import re
-
-from south.db import db
 from south.v2 import DataMigration
-from django.db import models
-
+from django.conf import settings
 
 # copied and slimmed down from fjord/base/browsers.py
 GECKO_TO_FIREFOXOS_VERSION = {
@@ -43,7 +41,8 @@ class Migration(DataMigration):
                         resp.browser_version = fxos_version
                         resp.save()
 
-        print '0012: {0} fixed'.format(working_set.count())
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), '{0} fixed'.format(working_set.count())
 
     def backwards(self, orm):
         working_set = orm.Response.objects.filter(product=u'Firefox OS')
@@ -60,7 +59,8 @@ class Migration(DataMigration):
                         resp.browser_version = fx_version
                         resp.save()
 
-        print '0012: {0} unfixed'.format(working_set.count())
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), '{0} unfixed'.format(working_set.count())
 
     models = {
         'feedback.response': {

--- a/fjord/feedback/migrations/0013_convert_firefoxos_to_firefox_os.py
+++ b/fjord/feedback/migrations/0013_convert_firefoxos_to_firefox_os.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
+import os
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
+
 
 class Migration(DataMigration):
-
     def forwards(self, orm):
         # Convert "FirefoxOS" -> "Firefox OS"
-        print 'updated', (orm.Response.objects
-                          .filter(platform=u'FirefoxOS')
-                          .update(platform=u'Firefox OS'))
+        ret = orm.Response.objects.filter(platform=u'FirefoxOS').update(platform=u'Firefox OS')
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), ret
 
     def backwards(self, orm):
         # Convert "Firefox OS" -> "FirefoxOS"
-        print 'updated', (orm.Response.objects
-                          .filter(platform=u'Firefox OS')
-                          .update(platform=u'FirefoxOS'))
+        ret = orm.Response.objects.filter(platform=u'Firefox OS').update(platform=u'FirefoxOS')
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), ret
 
     models = {
         'feedback.response': {

--- a/fjord/feedback/migrations/0014_convert_version_to_unknown.py
+++ b/fjord/feedback/migrations/0014_convert_version_to_unknown.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
+import os
 import re
-
-from south.db import db
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
 
 
 GECKO_TO_FIREFOXOS_VERSION = {
@@ -55,7 +54,8 @@ class Migration(DataMigration):
 
             resp.save()
 
-        print '0014: {0} fixed'.format(working_set.count())
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), '{0} fixed'.format(working_set.count())
 
     def backwards(self, orm):
         raise RuntimeError("Cannot reverse this migration.")

--- a/fjord/feedback/migrations/0015_windows_8_1.py
+++ b/fjord/feedback/migrations/0015_windows_8_1.py
@@ -1,21 +1,24 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
+import os
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
+
 
 class Migration(DataMigration):
     def forwards(self, orm):
         # Convert "Windows NT 6.3" to "Windows 8.1"
-        print 'updated', (orm.Response.objects
-                          .filter(platform=u'Windows NT 6.3')
-                          .update(platform=u'Windows 8.1'))
+
+        ret = orm.Response.objects.filter(platform=u'Windows NT 6.3').update(platform=u'Windows 8.1')
+
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), ret
 
     def backwards(self, orm):
         # Convert it back!
-        print 'updated', (orm.Response.objects
-                          .filter(platform=u'Windows 8.1')
-                          .update(platform=u'Windows NT 6.3'))
+        ret = orm.Response.objects.filter(platform=u'Windows 8.1').update(platform=u'Windows NT 6.3')
+
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), ret
 
     models = {
         'feedback.response': {

--- a/fjord/feedback/migrations/0017_truncate_description.py
+++ b/fjord/feedback/migrations/0017_truncate_description.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
+import os
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
 
 
 TRUNCATE_LENGTH = 10000
@@ -19,7 +18,8 @@ class Migration(DataMigration):
                 resp.save()
                 affected_count += 1
 
-        print 'Truncated {0} descriptions'.format(affected_count)
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), 'Truncated {0} descriptions'.format(affected_count)
 
     def backwards(self, orm):
         raise RuntimeError("Cannot reverse this migration.")

--- a/fjord/feedback/migrations/0018_strip_whitespace.py
+++ b/fjord/feedback/migrations/0018_strip_whitespace.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
+import os
 from south.v2 import DataMigration
-from django.db import models
+from django.conf import settings
+
 
 class Migration(DataMigration):
     def forwards(self, orm):
@@ -17,7 +17,8 @@ class Migration(DataMigration):
                 resp.save()
                 affected_count += 1
 
-        print 'Stripped {0} descriptions'.format(affected_count)
+        if not getattr(settings, 'TEST'):
+            print os.path.basename(__file__), 'Stripped {0} descriptions'.format(affected_count)
 
     def backwards(self, orm):
         raise RuntimeError("Cannot reverse this migration.")


### PR DESCRIPTION
- clean up migration imports (totally cosmetic)
- quells the stuff printed during tests because we rebuild the database
  and run all the migrations every time we run the tests and all this
  useless stuff got printed

Quick r?
