### PR TITLE
[bug 898584] Fix valueerror in dashboard

### DIFF
--- a/fjord/analytics/tests/test_views.py
+++ b/fjord/analytics/tests/test_views.py
@@ -332,6 +332,14 @@ class TestDashboardView(ElasticTestCase):
         pq = PyQuery(r.content)
         eq_(len(pq('li.opinion')), 4)
 
+    def test_date_start_valueerror(self):
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=898584
+        url = reverse('dashboard')
+        r = self.client.get(url, {
+                'date_start': '0001-01-01',
+            })
+        eq_(r.status_code, 200)
+
     def test_invalid_search(self):
         url = reverse('dashboard')
         # Invalid values for happy shouldn't filter

--- a/fjord/base/tests/test__util.py
+++ b/fjord/base/tests/test__util.py
@@ -40,7 +40,8 @@ class SmartIntTestCase(TestCase):
 class SmartDateTest(TestCase):
     def test_sanity(self):
         eq_(datetime(2012, 1, 1), smart_datetime('2012-01-01'))
-        eq_(datetime(1742, 11, 5), smart_datetime('1742-11-05'))
+        eq_(None, smart_datetime('1742-11-05'))
+        eq_(None, smart_datetime('0001-01-01'))
 
     def test_empty_string(self):
         eq_(None, smart_datetime(''))
@@ -50,7 +51,7 @@ class SmartDateTest(TestCase):
 
     def test_format(self):
         eq_(datetime(2012, 9, 28),
-            smart_datetime('9/28/2012', format='%m/%d/%Y'))
+            smart_datetime('9/28/2012', fmt='%m/%d/%Y'))
 
     def test_null_bytes(self):
         # strptime likes to barf on null bytes in strings, so test it.

--- a/fjord/base/util.py
+++ b/fjord/base/util.py
@@ -88,22 +88,28 @@ def smart_int(s, fallback=0):
         return fallback
 
 
-def smart_datetime(s, format='%Y-%m-%d', fallback=None):
+def smart_datetime(s, fmt='%Y-%m-%d', fallback=None):
     """Convert a string to a datetime, with a fallback for invalid input.
 
     Note that this won't take ``datetime``s as input, only strings. It is
     different than ``smart_int`` in this way.
 
     :arg s: The string to convert to a date.
-    :arg format: Format to use to parse the string into a date.
+    :arg fmt: Format to use to parse the string into a date.
         Default: ``'%Y-%m-%d'``.
     :arg fallback: Value to use in case of an error. Default: ``None``.
 
     """
     try:
-        return datetime.strptime(s, format)
+        dt = datetime.strptime(s, fmt)
+        # The strftime functions require a year >= 1900, so if this
+        # has a year before that, then it's not a valid date.
+        if dt.year >= 1900:
+            return dt
     except (ValueError, TypeError):
-        return fallback
+        pass
+
+    return fallback
 
 
 def smart_bool(s, fallback=False):


### PR DESCRIPTION
If you passed a start date of 0001-01-01 which is a valid date format,
but isn't really a valid date, then when that gets run through strftime,
it throws an error about how strftime only handles dates with year >=
1900.

This fixes that by treating dates with years < 1900 as not valid.

r?
