### PR TITLE
[bug 946736] Fix date links on responses in dashboard

### DIFF
--- a/fjord/analytics/templates/analytics/dashboard.html
+++ b/fjord/analytics/templates/analytics/dashboard.html
@@ -23,8 +23,7 @@
    for all datetimes in PDT. #}
       <li>
        {% set created_date = to_date_string(feedback.created) %}
-       {% set created_dt = to_datetime_string(feedback.created) %}
-       <a href="{{ request.get_full_path()|urlparams(date_start=created_dt) }}">
+       <a href="{{ request.get_full_path()|urlparams(date_start=created_date, date_end=created_date) }}">
           <time datetime="{{ created_date }}-08:00" title="{{ created_date }} PST">
             {{ feedback.created|naturaltime }}
           </time>

--- a/fjord/analytics/templates/analytics/response.html
+++ b/fjord/analytics/templates/analytics/response.html
@@ -34,8 +34,7 @@
                for all datetimes in PDT.
             #}
             {% set created_date = to_date_string(response.created) %}
-            {% set created_dt = to_datetime_string(response.created) %}
-            <a href="{{ url('dashboard')|urlparams(date_start=created_dt) }}">
+            <a href="{{ url('dashboard')|urlparams(date_start=created_date, date_end=created_date) }}">
               <time datetime="{{ created_date }}-08:00" title="{{ created_date }} PST">
                 {{ response.created|naturaltime }}
               </time>


### PR DESCRIPTION
This fixes the date links on responses in the dashboard to send a date for start_date instead of a datetime.

In doing that, I discovered we don't use the poorly named "created_dt", so I nixed it.

Quick r?
