### PR TITLE
[bug 754615] Remove response urls from feeds

### DIFF
--- a/fjord/analytics/tests/test_views.py
+++ b/fjord/analytics/tests/test_views.py
@@ -299,21 +299,23 @@ class TestDashboardView(ElasticTestCase):
 
         assert 'http://www.w3.org/2005/Atom' in r.content
 
-    def test_search_format_atom_has_related_links(self):
-        """Atom output works"""
-        response(description='relatedlinks', url='http://example.com', save=True)
-        self.refresh()
+    # FIXME - This was backed out. We can re-enable this test when urls are
+    # re-added.
+    # def test_search_format_atom_has_related_links(self):
+    #     """Atom output works"""
+    #     response(description='relatedlinks', url='http://example.com', save=True)
+    #     self.refresh()
 
-        url = reverse('dashboard')
-        # Text search
-        r = self.client.get(url, {'q': 'relatedlinks', 'format': 'atom'})
-        eq_(r.status_code, 200)
+    #     url = reverse('dashboard')
+    #     # Text search
+    #     r = self.client.get(url, {'q': 'relatedlinks', 'format': 'atom'})
+    #     eq_(r.status_code, 200)
 
-        assert 'http://www.w3.org/2005/Atom' in r.content
-        # FIXME: This is a lousy way to test for a single link with
-        # both attributes.
-        assert 'rel="related"' in r.content
-        assert 'href="http://example.com"' in r.content
+    #     assert 'http://www.w3.org/2005/Atom' in r.content
+    #     # FIXME: This is a lousy way to test for a single link with
+    #     # both attributes.
+    #     assert 'rel="related"' in r.content
+    #     assert 'href="http://example.com"' in r.content
 
     def test_date_search(self):
         url = reverse('dashboard')

--- a/fjord/analytics/views.py
+++ b/fjord/analytics/views.py
@@ -212,7 +212,7 @@ def generate_atom_feed(request, search):
             link=link_url,
             pubdate=response.created,
             categories=categories,
-            link_related=response.url
+            # link_related=response.url
         )
     return HttpResponse(
         feed.writeString('utf-8'), mimetype='application/atom+xml')

--- a/fjord/base/util.py
+++ b/fjord/base/util.py
@@ -176,7 +176,7 @@ class Atom1FeedWithRelatedLinks(Atom1Feed):
 
     def add_item_elements(self, handler, item):
         super(Atom1FeedWithRelatedLinks, self).add_item_elements(handler, item)
-        if item['link_related']:
+        if item.get('link_related'):
             handler.addQuickElement(
                 'link',
                 attrs={'href': item['link_related'], 'rel': 'related'})


### PR DESCRIPTION
This needs to be redone and requires additional work to be done, too.
For now, we're removing it from the feeds until that work is done. Refer
to the bug for details.

r?
