### PR TITLE
Add product and version to dashboard

### DIFF
--- a/fjord/analytics/templates/analytics/dashboard.html
+++ b/fjord/analytics/templates/analytics/dashboard.html
@@ -29,6 +29,14 @@
           </time>
         </a>
       </li>
+      {% if feedback.product %}
+        <li>
+          <a href="{{ request.get_full_path()|urlparams(product=feedback.product) }}">{{ feedback.product|unknown }}</a>
+          {% if feedback.version %}
+            <a href="{{ request.get_full_path()|urlparams(product=feedback.product, version=feedback.version) }}">{{ feedback.version|unknown }}</a>
+          {% endif %}
+        </li>
+      {% endif %}
       <li><a href="{{ request.get_full_path()|urlparams(platform=feedback.platform) }}">{{ feedback.platform|unknown }}</a></li>
       <li><a href="{{ request.get_full_path()|urlparams(locale=feedback.locale) }}">{{ feedback.locale|locale_name }}</a></li>
       <li><a href="{{ url('response_view', responseid=feedback.id) }}">{{ _('Permalink') }}</a></li>


### PR DESCRIPTION
This makes it easier to test multiple product urls since I can see from the dashboard whether it's working.

It shows the product and version if available with appropriate dashboard filtering links.

Quick r?
