### PR TITLE
Move product, version and channel out of secure section

### DIFF
--- a/fjord/analytics/templates/analytics/response.html
+++ b/fjord/analytics/templates/analytics/response.html
@@ -52,6 +52,18 @@
               {{ response.locale|locale_name }}
             </a>
           </dd>
+          <dt>{{ _('Product') }}</dt>
+          <dd>
+            {{ response.product|unknown }}
+          </dd>
+          <dt>{{ _('Version') }}</dt>
+          <dd>
+            {{ response.version|unknown }}
+          </dd>
+          <dt>{{ _('Channel') }}</dt>
+          <dd>
+            {{ response.channel|unknown }}
+          </dd>
         </dl>
 
         {% if user.is_authenticated() and user.has_perm('analytics.can_view_dashboard') %}
@@ -59,18 +71,6 @@
             <dt>{{ _('URL') }}</dt>
             <dd>
               {{ response.url or 'None' }}
-            </dd>
-            <dt>{{ _('Product') }}</dt>
-            <dd>
-              {{ response.product|unknown }}
-            </dd>
-            <dt>{{ _('Channel') }}</dt>
-            <dd>
-              {{ response.channel|unknown }}
-            </dd>
-            <dt>{{ _('Version') }}</dt>
-            <dd>
-              {{ response.version|unknown }}
             </dd>
             <dt>{{ _('Country') }}</dt>
             <dd>


### PR DESCRIPTION
The product, version and channel aren't PII, so it should be fine to
show them. Given that I just changed the dashboard to show the product
and version, it seemed prudent to fix it here, too.

Quick r?
