### PR TITLE
[bug 933786] Fix strip error

### DIFF
--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -102,6 +102,26 @@ class TestFeedbackAPI(TestCase):
         email = models.ResponseEmail.objects.latest(field_name='id')
         eq_(email.email, data['email'])
 
+    def test_null_device_returns_400(self):
+        data = {
+            'happy': True,
+            'description': u'Great!',
+            'product': u'Firefox OS',
+            'device': None
+        }
+
+        r = self.client.post(reverse('api-post-feedback'), data)
+        eq_(r.status_code, 201)
+
+        feedback = models.Response.objects.latest(field_name='id')
+        eq_(feedback.happy, True)
+        eq_(feedback.description, data['description'])
+        eq_(feedback.product, data['product'])
+
+        # Fills in defaults
+        eq_(feedback.url, u'')
+        eq_(feedback.user_agent, u'api')
+
     def test_invalid_email_address_returns_400(self):
         data = {
             'happy': True,


### PR DESCRIPTION
We get this weird error on input-stage (and only on stage) where someone
is using the Input API and sending in nonsensical POST data and it
somehow manages to result in attrs['device'] being None which causes an
error.

I spent some time looking into it and I can't figure out how it ends up
as a None. I don't know what the actual input that's causing the error
is.

Regardless, this alleviates that by making sure it's a unicode but it's
goofipants.

r?
