### PR TITLE
Tweak deploy to handle vendor/ switching

### DIFF
--- a/bin/update/update.py
+++ b/bin/update/update.py
@@ -20,6 +20,10 @@ def update_code(ctx, tag):
     """Update the code to a specific git reference (tag/sha/etc)."""
     with ctx.lcd(settings.SRC_DIR):
         ctx.local('git fetch')
+
+        # FIXME - remove this after we're past vendor/ fixing
+        ctx.local('rm -rf vendor vendor-local')
+
         ctx.local('git checkout -f %s' % tag)
         ctx.local('git submodule sync')
         ctx.local('git submodule update --init --recursive')


### PR DESCRIPTION
This tweaks the deploy script so that it deletes the vendor/ and
vendor-local/ directories before doing a git checkout.

The theory is that landing this before we land the vendor/ overhaul
allows everything to work without manual intervention.

r?
