### PR TITLE
[bug 982242] Add description_terms field

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -16,7 +16,8 @@ from fjord.feedback.config import CODE_TO_COUNTRY
 from fjord.feedback.utils import compute_grams
 from fjord.search.index import (
     register_mapping_type, FjordMappingType,
-    boolean_type, date_type, integer_type, keyword_type, text_type)
+    boolean_type, date_type, integer_type, keyword_type, terms_type,
+    text_type)
 from fjord.search.tasks import register_live_index
 
 
@@ -244,6 +245,7 @@ class ResponseMappingType(FjordMappingType, Indexable):
             'has_email': boolean_type(),
             'description': text_type(),
             'description_bigrams': keyword_type(),
+            'description_terms': terms_type(),
             'user_agent': keyword_type(),
             'product': keyword_type(),
             'channel': keyword_type(),
@@ -274,6 +276,7 @@ class ResponseMappingType(FjordMappingType, Indexable):
             'url_domain': obj.url_domain,
             'has_email': bool(obj.user_email),
             'description': obj.description,
+            'description_terms': obj.description,
             'user_agent': obj.user_agent,
             'product': obj.product,
             'channel': obj.channel,

--- a/fjord/search/index.py
+++ b/fjord/search/index.py
@@ -107,6 +107,10 @@ def keyword_type():
     return {'type': 'string', 'analyzer': 'keyword'}
 
 
+def terms_type():
+    return {'type': 'string', 'analyzer': 'standard'}
+
+
 def text_type():
     return {'type': 'string', 'analyzer': 'snowball'}
 


### PR DESCRIPTION
This adds a new field to the index that has a different analyzer than
the existing description field. This one doesn't do stemming so it's
good for the terms facet.

Wait, what? Yeah, so when Elasticsearch does stemming, it stores things
in the index like "becaus" instead of "because". That's great for
searching, but lousy for doing other things with the resulting tokens
like word clouds, comparing sets of bigrams, etc.

r?
