### PR TITLE
Fix deprecated defaults module usage

### DIFF
--- a/fjord/analytics/urls.py
+++ b/fjord/analytics/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns(

--- a/fjord/base/urls.py
+++ b/fjord/base/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('fjord.base.views',

--- a/fjord/feedback/urls.py
+++ b/fjord/feedback/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from fjord.feedback import views
 

--- a/fjord/urls.py
+++ b/fjord/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import patterns, include
+from django.conf.urls import patterns, include
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.http import HttpResponse


### PR DESCRIPTION
Stuff in django.conf.urls.defaults was moved in Django 1.4 and
deprecated in Django 1.5.

r?
