### PR TITLE
[bug 986071] Fixes the cyoa page

### DIFF
--- a/fjord/feedback/static/js/cyoa.js
+++ b/fjord/feedback/static/js/cyoa.js
@@ -1,0 +1,8 @@
+(function($) {
+    document.addEventListener('DOMComponentsLoaded', function firstCard() {
+        var xdeck = $('x-deck')[0];
+        document.removeEventListener('DOMComponentsLoaded', firstCard);
+        xdeck.showCard(0);
+    });
+
+}(jQuery));

--- a/fjord/feedback/templates/feedback/cyoa.html
+++ b/fjord/feedback/templates/feedback/cyoa.html
@@ -3,12 +3,15 @@
 
 {% block page_title %}Which product?{% endblock %}
 
+{% block site_js %}
+  <script src="{{ settings.STATIC_URL }}js/lib/brick-1.0.0.byob.min.js"></script>
+  {{ js('cyoa') }}
+{% endblock %}
+
 {% block body %}
   <x-deck>
     <x-card id="picker">
-      <x-appbar>
-        <header>Which product?</header>
-      </x-appbar>
+      <x-appbar heading="Which product?" subheading=""></x-appbar>
 
       <section>
         <p>

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -262,6 +262,11 @@ MINIFY_BUNDLES = {
             'js/init.js',
             'js/ga.js',
         ),
+        'cyoa': (
+            'js/lib/jquery.min.js',
+            'js/cyoa.js',
+            'js/ga.js',
+        ),
         'generic_feedback': (
             'js/lib/jquery.min.js',
             'js/common_feedback.js',


### PR DESCRIPTION
The cyoa page broke when we updated brick and changed around
generic_feedback.js. It probably shouldn't be relying on
generic_feedback.js, so this fixes that and also makes it work properly.

r?
