### PR TITLE
[bug 989526] Fix unknown product error page

### DIFF
--- a/fjord/feedback/static/js/cyoa.js
+++ b/fjord/feedback/static/js/cyoa.js
@@ -1,8 +1,0 @@
-(function($) {
-    document.addEventListener('DOMComponentsLoaded', function firstCard() {
-        var xdeck = $('x-deck')[0];
-        document.removeEventListener('DOMComponentsLoaded', firstCard);
-        xdeck.showCard(0);
-    });
-
-}(jQuery));

--- a/fjord/feedback/templates/feedback/cyoa.html
+++ b/fjord/feedback/templates/feedback/cyoa.html
@@ -5,11 +5,11 @@
 
 {% block site_js %}
   <script src="{{ settings.STATIC_URL }}js/lib/brick-1.0.0.byob.min.js"></script>
-  {{ js('cyoa') }}
+  {{ js('singlecard') }}
 {% endblock %}
 
 {% block body %}
-  <x-deck>
+  <x-deck selected-index=0>
     <x-card id="picker">
       <x-appbar heading="Which product?" subheading=""></x-appbar>
 

--- a/fjord/feedback/templates/feedback/unknownproduct.html
+++ b/fjord/feedback/templates/feedback/unknownproduct.html
@@ -2,12 +2,15 @@
 
 {% block page_title %}{{ _('Unknown product') }}{% endblock %}
 
+{% block site_js %}
+  <script src="{{ settings.STATIC_URL }}js/lib/brick-1.0.0.byob.min.js"></script>
+  {{ js('singlecard') }}
+{% endblock %}
+
 {% block body %}
-  <x-deck>
+  <x-deck selected-index=0>
     <x-card id="unknownproduct">
-      <x-appbar>
-        <header>{{ _('Unknown product') }}</header>
-      </x-appbar>
+      <x-appbar heading="{{ _('Unknown product') }}" subheading=""></x-appbar>
 
       <section>
         <div class="content">

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -262,9 +262,8 @@ MINIFY_BUNDLES = {
             'js/init.js',
             'js/ga.js',
         ),
-        'cyoa': (
+        'singlecard': (
             'js/lib/jquery.min.js',
-            'js/cyoa.js',
             'js/ga.js',
         ),
         'generic_feedback': (


### PR DESCRIPTION
This fixes the unknown product error page so it shows. This broke after
we updated Brick.

Further, it re-fixes the cyoa page so that it uses selected-index
attribute rather than js to set the initial x-card to show.

r?
