### PR TITLE
[bug 949461] Hack spam delete link

### DIFF
--- a/fjord/analytics/templates/analytics/analyzer/duplicates.html
+++ b/fjord/analytics/templates/analytics/analyzer/duplicates.html
@@ -50,6 +50,11 @@
                 <p>{{ desc }}</p>
               </td>
               <td>
+                <p>
+                  <b>Actions:</b>
+{# FIXME: This is hardcoded and goofy. Better delete measures will come later in bug #949461. #}
+                  <a href="/admin/feedback/response/?q={{ desc|replace('\n', ' ')|truncate(100, False, '') }}">Delete in admin</a>
+                </p>
                 <table class="details">
                   <tbody>
                     {% for resp in responses %}


### PR DESCRIPTION
This makes it easier to delete a batch of spam from the spam duplicates
report (ab)using the existing admin tools.

Quick r?
