### PR TITLE
[bug 976711] Add source, campaign and organic facets

### DIFF
--- a/fjord/analytics/templates/analytics/response.html
+++ b/fjord/analytics/templates/analytics/response.html
@@ -66,7 +66,15 @@
           </dd>
           <dt>{{ _('URL Domain') }}</dt>
           <dd>
-            {{ response.url_domain or 'None' }}
+            {{ response.url_domain or _('None') }}
+          </dd>
+          <dt>{{ _('Source') }}</dt>
+          <dd>
+            {{ response.source or _('None') }}
+          </dd>
+          <dt>{{ _('Campaign') }}</dt>
+          <dd>
+            {{ response.campaign or _('None') }}
           </dd>
         </dl>
 

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -343,6 +343,10 @@ class ResponseMappingType(FjordMappingType, Indexable):
             'country': keyword_type(),
             'device': keyword_type(),
             'manufacturer': keyword_type(),
+            'source': keyword_type(),
+            'campaign': keyword_type(),
+            'source_campaign': keyword_type(),
+            'organic': boolean_type(),
             'created': date_type(),
         }
 
@@ -372,6 +376,13 @@ class ResponseMappingType(FjordMappingType, Indexable):
             'country': obj.country,
             'device': obj.device,
             'manufacturer': obj.manufacturer,
+            'source': obj.source,
+            'campaign': obj.campaign,
+            'source_campaign': '::'.join([
+                (obj.source or '--'),
+                (obj.campaign or '--')
+            ]),
+            'organic': (not obj.source and not obj.campaign),
             'created': obj.created,
         }
 


### PR DESCRIPTION
This adds "source", "campaign" and "organic" facets to the analyzer
search dashboard. In order to add these, I had to add some additional
fields to the mapping.

While doing that, I figured I'd add a "source :: campaign" composite
field which I'm not going to use now, but figured I'd use at some point
since it seems handy.

r?
