### PR TITLE
[bug 1026019] Rework bigram generation

### DIFF
--- a/fjord/feedback/tests/test__utils.py
+++ b/fjord/feedback/tests/test__utils.py
@@ -3,7 +3,7 @@ from django.test.client import RequestFactory
 from nose.tools import eq_, ok_
 
 from fjord.base.tests import TestCase, reverse
-from fjord.feedback.utils import actual_ip_plus_desc, clean_url
+from fjord.feedback.utils import actual_ip_plus_desc, clean_url, compute_grams
 
 
 class Testactual_ip_plus_desc(TestCase):
@@ -71,3 +71,45 @@ class Testclean_url(TestCase):
 
         for url, expected in data:
             eq_(clean_url(url), expected)
+
+
+class TestComputeGrams(TestCase):
+    # FIXME - Beef this up so that we have more comprehensive tests of the various
+    # tokenizing edge cases.
+
+    def test_basic(self):
+        test_data = [
+            ('The quick brown fox', [u'brown quick', u'brown fox']),
+
+            ('the latest update disables the New tab function',
+             [u'disables new', u'function tab', u'new tab', u'latest update',
+              u'disables update']),
+
+            ('why is firefox so damn slow???? many tabs load slow or not at '
+             'all!',
+             [u'load tabs', u'load slow', u'slow tabs', u'damn slow']),
+
+            ("I'm one of the guys that likes to try Firefox ahead of the "
+             "herd... usually I use Nightly, but then a while back my "
+             "favorite add-on, TabMixPlus stopped working because Firefox "
+             "redid something in the code. \"No problem,\" says I to myself, "
+             "I'll just use Aurora until they get it fixed.",
+             [u'add-on favorite', u'add-on tabmixplus', u'ahead herd',
+              u'ahead try', u'aurora fixed', u'aurora use', u'code problem',
+              u'code redid', u'favorite nightly', u"guys i'm", u'guys likes',
+              u'herd usually', u"i'll just", u"i'll myself", u'just use',
+              u'likes try', u'myself says', u'nightly use', u'problem says',
+              u'redid working', u'stopped tabmixplus', u'stopped working',
+              u'use usually']),
+
+            ('Being partially sighted, I found the features with Windows XP '
+             'and IE8 extremely usefu;. I need everything in Arial black bold '
+             'text.',
+             [u'extremely usefu', u'features sighted', u'windows xp', u'ie8 xp',
+              u'black bold', u'partially sighted', u'need usefu',
+              u'features windows', u'arial need', u'arial black', u'bold text',
+              u'extremely ie8']),
+        ]
+
+        for text, expected in test_data:
+            eq_(sorted(compute_grams(text)), sorted(expected))


### PR DESCRIPTION
This reworks the tokenizing part of bigram generation so that it's no
longer (ab)using Elasticsearch to do the work. Now it does its own
tokenizing.

I also added some really rough tests to make sure the new tokenizing
wasn't really horrible. The tests run roughly the same before and after
the code changes. The new code handles the "add-on" case better--the old
code broke that into "add" and "on" and then ditched "on".

This radically improves reindexing. Cuts reindexing times in half or better.

r?
