### PR TITLE
[Bug 1042222] update Vagrantfile to use 14.04 LTS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,8 @@ MOUNT_POINT = '/home/vagrant/fjord'
 
 
 Vagrant::Config.run do |config|
-    config.vm.box = "saucy64"
-    config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/saucy/current/saucy-server-cloudimg-amd64-vagrant-disk1.box"
+    config.vm.box = "trusty64"
+    config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
     Vagrant.configure("1") do |config|
         config.vm.customize ["modifyvm", :id, "--memory", CONF['memory']]


### PR DESCRIPTION
This updates the Vagrantfile to use the 14.04 LTS image instead
of 13.10 which has reached end of life.
