### PR TITLE
[bug 1057617] Fix url data validation

### DIFF
--- a/fjord/base/forms.py
+++ b/fjord/base/forms.py
@@ -1,0 +1,22 @@
+from django.forms import fields
+
+from fjord.base.validators import EnhancedURLValidator
+
+
+class EnhancedURLField(fields.URLField):
+    """URLField that also supports about: and chrome:// urls"""
+    def __init__(self, max_length=None, min_length=None, *args, **kwargs):
+        super(EnhancedURLField, self).__init__(
+            max_length, min_length, *args, **kwargs)
+        # The last validator in the list is the URLValidator we don't
+        # like. Replace that one with ours.
+        self.validators[-1] = EnhancedURLValidator()
+
+    def to_python(self, value):
+        if value:
+            # Don't "clean" about: and chrome:// urls--just pass them
+            # through.
+            if value.startswith(('about:', 'chrome://')):
+                return value
+
+        return super(EnhancedURLField, self).to_python(value)

--- a/fjord/base/models.py
+++ b/fjord/base/models.py
@@ -6,6 +6,9 @@ from django.db import models
 import caching.base
 from tower import ugettext_lazy as _lazy
 
+from fjord.base import forms
+from fjord.base.validators import EnhancedURLValidator
+
 
 class ModelBase(caching.base.CachingMixin, models.Model):
     """Common base model for all models: Implements caching."""
@@ -19,6 +22,27 @@ class ModelBase(caching.base.CachingMixin, models.Model):
 
 class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
+
+
+class EnhancedURLField(models.CharField):
+    """URLField that also supports about: and chrome:// urls"""
+    description = 'Enhanced URL'
+
+    def __init__(self, verbose_name=None, name=None, **kwargs):
+        kwargs['max_length'] = kwargs.get('max_length', 200)
+        models.CharField.__init__(self, verbose_name, name, **kwargs)
+        self.validators.append(EnhancedURLValidator())
+
+    def formfield(self, **kwargs):
+        defaults = {
+            'form_class': forms.EnhancedURLField,
+        }
+        defaults.update(kwargs)
+        return super(EnhancedURLField, self).formfield(**defaults)
+
+
+from south.modelsinspector import add_introspection_rules
+add_introspection_rules([], ["^fjord\.base\.models\.EnhancedURLField"])
 
 
 class JSONObjectField(models.TextField):

--- a/fjord/base/tests/test_forms.py
+++ b/fjord/base/tests/test_forms.py
@@ -1,0 +1,67 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from nose.tools import eq_
+
+from fjord.base.forms import EnhancedURLField
+
+
+class EnhancedURLFieldTests(TestCase):
+    def test_valid(self):
+        test_data = [
+            # expected, url
+            ('about:mozilla', 'about:mozilla'),
+            ('chrome://foo', 'chrome://foo'),
+            ('ftp://example.com/', 'ftp://example.com'),
+
+            # From Django's URLField test data
+            ('http://localhost/', 'http://localhost'),
+            ('http://example.com/', 'http://example.com'),
+            ('http://example.com./', 'http://example.com.'),
+            ('http://www.example.com/', 'http://www.example.com'),
+            ('http://www.example.com:8000/test', 'http://www.example.com:8000/test'),
+            ('http://valid-with-hyphens.com/', 'valid-with-hyphens.com'),
+            ('http://subdomain.domain.com/', 'subdomain.domain.com'),
+            ('http://200.8.9.10/', 'http://200.8.9.10'),
+            ('http://200.8.9.10:8000/test', 'http://200.8.9.10:8000/test'),
+            ('http://valid-----hyphens.com/', 'http://valid-----hyphens.com'),
+            ('http://www.example.com/s/http://code.djangoproject.com/ticket/13804',
+             'www.example.com/s/http://code.djangoproject.com/ticket/13804'),
+        ]
+
+        f = EnhancedURLField()
+
+        for expected, url in test_data:
+            try:
+                eq_(f.clean(url), expected)
+            except ValidationError:
+                print url
+                raise
+
+    def test_invalid(self):
+        test_data = [
+            # From Django's URLField test data
+            ('This field is required.', ''),
+            ('This field is required.', None),
+            ('Enter a valid URL.', 'foo'),
+            ('Enter a valid URL.', 'http://'),
+            ('Enter a valid URL.', 'http://example'),
+            ('Enter a valid URL.', 'http://example.'),
+            ('Enter a valid URL.', 'com.'),
+            ('Enter a valid URL.', '.'),
+            ('Enter a valid URL.', 'http://.com'),
+            ('Enter a valid URL.', 'http://invalid-.com'),
+            ('Enter a valid URL.', 'http://-invalid.com'),
+            ('Enter a valid URL.', 'http://inv-.alid-.com'),
+            ('Enter a valid URL.', 'http://inv-.-alid.com'),
+            ('Enter a valid URL.', '[a'),
+            ('Enter a valid URL.', 'http://[a'),
+        ]
+
+        f = EnhancedURLField()
+
+        for msg, url in test_data:
+            try:
+                f.clean(url)
+            except ValidationError as exc:
+                eq_(exc.messages, [msg])

--- a/fjord/base/tests/test_validators.py
+++ b/fjord/base/tests/test_validators.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+
+from django.core.exceptions import ValidationError
+
+from nose.tools import eq_
+
+from fjord.base.validators import EnhancedURLValidator
+
+
+class EnhancedURLValidatorTests(TestCase):
+    def test_valid_urls(self):
+        test_data = [
+            'example.com',
+            'example.com:80',
+            'example.com:80/foo',
+            'http://example.com',
+            'http://example.com/foo',
+            'http://example.com:80',
+            'http://example.com:80/foo',
+            'https://example.com',
+            'https://example.com/foo',
+            'https://example.com:80',
+            'https://example.com:80/foo',
+            'ftp://example.com',
+            'about:mozilla',
+            'chrome://foo',
+
+            # Taken from Django's URLValidator test case data
+            'http://www.djangoproject.com/',
+            'http://localhost/',
+            'http://example.com/',
+            'http://www.example.com/',
+            'http://www.example.com:8000/test'
+            'http://valid-with-hyphens.com/',
+            'http://subdomain.example.com/',
+            'http://200.8.9.10/',
+            'http://200.8.9.10:8000/test',
+            'http://valid-----hyphens.com/',
+            'http://example.com?something=value',
+            'http://example.com/index.php?something=value&another=value2',
+        ]
+
+        validator = EnhancedURLValidator()
+
+        for url in test_data:
+            validator(url)
+
+    def test_invalid_urls(self):
+        test_data = [
+            'foo',
+            'http://',
+            'http://example',
+            'http://example.'
+            'http://.com',
+            'http://invalid-.com',
+            'http://-invalid.com',
+            'http://inv-.alid-.com',
+            'http://inv-.-alid.com'
+        ]
+
+        validator = EnhancedURLValidator()
+
+        for url in test_data:
+            self.assertRaises(ValidationError, validator, url)

--- a/fjord/base/validators.py
+++ b/fjord/base/validators.py
@@ -1,0 +1,14 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+
+from fjord.base.util import is_url
+
+
+class EnhancedURLValidator(URLValidator):
+    """URLValidator that also validates about: and chrome:// urls"""
+    def __call__(self, value):
+        # is_url turns around and uses URLValidator regex, so this
+        # covers everything URLValidator covers plus some other
+        # things.
+        if not is_url(value):
+            raise ValidationError(self.message, code=self.code)

--- a/fjord/feedback/forms.py
+++ b/fjord/feedback/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from fjord.base.forms import EnhancedURLField
+
 
 class URLInput(forms.TextInput):
     """Text field with HTML5 URL Input type."""
@@ -11,7 +13,7 @@ class ResponseForm(forms.Form):
 
     # NB: The class 'url' is hard-coded in the Testpilot extension to
     # accommodate pre-filling the field client-side.
-    url = forms.URLField(required=False, widget=forms.TextInput(
+    url = EnhancedURLField(required=False, widget=forms.TextInput(
         attrs={'placeholder': 'http://', 'class': 'url'}))
 
     description = forms.CharField(widget=forms.Textarea(), required=True)

--- a/fjord/feedback/migrations/0029_auto__chg_field_response_url.py
+++ b/fjord/feedback/migrations/0029_auto__chg_field_response_url.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Response.url'
+        db.alter_column(u'feedback_response', 'url', self.gf('fjord.base.models.EnhancedURLField')(max_length=200))
+
+    def backwards(self, orm):
+
+        # Changing field 'Response.url'
+        db.alter_column(u'feedback_response', 'url', self.gf('django.db.models.fields.URLField')(max_length=200))
+
+    models = {
+        u'feedback.product': {
+            'Meta': {'object_name': 'Product'},
+            'db_name': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'on_dashboard': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'translation_system': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'api': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'campaign': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'prodchan': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('fjord.base.models.EnhancedURLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        u'feedback.responsecontext': {
+            'Meta': {'object_name': 'ResponseContext'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': "u'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']

--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -578,6 +578,40 @@ class PostFeedbackAPITest(TestCase):
         r = self.client.post(reverse('feedback-api'), data)
         eq_(r.status_code, 400)
 
+    def test_valid_urls(self):
+        test_data = [
+            'example.com',
+            'example.com:80',
+            'example.com:80/foo',
+            'http://example.com',
+            'http://example.com/foo',
+            'http://example.com:80',
+            'http://example.com:80/foo',
+            'https://example.com',
+            'https://example.com/foo',
+            'https://example.com:80',
+            'https://example.com:80/foo',
+            'ftp://example.com',
+            'about:mozilla',
+            'chrome://foo'
+        ]
+        for url in test_data:
+            data = {
+                'happy': True,
+                'channel': u'stable',
+                'version': u'1.1',
+                'description': u'Great!',
+                'product': u'Firefox OS',
+                'platform': u'Firefox OS',
+                'url': url,
+                'locale': 'en-US',
+            }
+
+            r = self.client.post(reverse('feedback-api'), data)
+            eq_(r.status_code, 201, msg=('%s != 201 (%s)' % (r.status_code, url)))
+
+            cache.clear()
+
 
 class PostFeedbackAPIThrottleTest(TestCase):
     def test_throttle(self):


### PR DESCRIPTION
This reworks all "url" field things so that "about:" and "chrome://" are
also valid urls.
- add EnhancedURLValidator, form EnhancedURLField, db model
  EnhancedURLField
- update the Input API to handle incoming "about:" and "chrome://" urls
- update the Input form handling to handle incoming "about:" and
  "chrome://" urls (the code suggests it could handle these already, but
  it seems like it was never tested)
- add a lot of tests for the form EnhancedURLField and the
  EnhancedURLValidator

This covers everything in the bug except the JavaScript URL validation.
That needs to be rewritten to allow for "about:" and "chrome://" urls.

r?
