### PR TITLE
fix bug 1012965 - Date picker looks broken in chrome

### DIFF
--- a/fjord/analytics/static/css/dashboard.less
+++ b/fjord/analytics/static/css/dashboard.less
@@ -354,7 +354,7 @@ ul.bars {
 #whentext {
   margin-top: 5px;
   input[type=date] {
-    width: 75px;
+    width: 9em;
   }
 }
 

--- a/fjord/analytics/static/js/dashboard.js
+++ b/fjord/analytics/static/js/dashboard.js
@@ -12,10 +12,11 @@ $(function() {
     });
 
     // Datepickers.
-    $('input[type=date]').datepicker({
-        dateFormat: 'yy-mm-dd',
-    });
-
+    if (!fjord.isDateInputSupported()) {
+        $('input[type=date]').datepicker({
+            dateFormat: 'yy-mm-dd',
+        });
+    }
 
     // Set up the when selector.
     var $date_start = $('#whensubmit').siblings('input[name=date_start]');

--- a/fjord/analytics/static/js/hourly_dashboard.js
+++ b/fjord/analytics/static/js/hourly_dashboard.js
@@ -2,9 +2,11 @@ $(function() {
     var $histogram = $('.graph .hourly-histogram');
 
     // Datepickers.
-    $('input[type=date]').datepicker({
-        dateFormat: 'yy-mm-dd',
-    });
+    if (!fjord.isDateInputSupported()) {
+        $('input[type=date]').datepicker({
+            dateFormat: 'yy-mm-dd',
+        });
+    }
 
     // Set up the when selector.
     var $date_end = $('#whensubmit').siblings('input[name=date_end]');

--- a/fjord/analytics/static/js/product_dashboard.js
+++ b/fjord/analytics/static/js/product_dashboard.js
@@ -1,8 +1,10 @@
 $(function() {
     // Datepickers.
-    $('input[type=date]').datepicker({
-        dateFormat: 'yy-mm-dd'
-    });
+    if (!fjord.isDateInputSupported()) {
+        $('input[type=date]').datepicker({
+            dateFormat: 'yy-mm-dd'
+        });
+    }
 
     // Set up the when selector.
     var $date_start = $('#whensubmit').siblings('input[name=date_start]');

--- a/fjord/analytics/static/js/product_dashboard_firefox.js
+++ b/fjord/analytics/static/js/product_dashboard_firefox.js
@@ -2,9 +2,11 @@ $(function() {
     var $vhistogram = $('.graph .versionhistogram');
 
     // Datepickers.
-    $('input[type=date]').datepicker({
-        dateFormat: 'yy-mm-dd'
-    });
+    if (!fjord.isDateInputSupported()) {
+        $('input[type=date]').datepicker({
+            dateFormat: 'yy-mm-dd'
+        });
+    }
 
     // Set up the when selector.
     var $date_start = $('#whensubmit').siblings('input[name=date_start]');

--- a/fjord/base/static/js/fjord_utils.js
+++ b/fjord/base/static/js/fjord_utils.js
@@ -77,4 +77,17 @@ window.fjord = window.fjord || {};
         }
         window.location.search = '?' + parts.join('&');
     };
+
+    /**
+     * Detect browser <input type="date" ...> support
+     * @returns {boolean}
+     */
+    fjord.isDateInputSupported = function() {
+        var input = document.createElement('input');
+        input.setAttribute('type','date');
+        var notADateValue = 'not-a-date';
+        input.setAttribute('value', notADateValue);
+
+        return input.value !== notADateValue;
+    };
 }());


### PR DESCRIPTION
I implemented a check that sets the boolean `dateInputSupported` on `window`.
In case date inputs are supported by the browser, jQuery UI is not used. This is especially nice for mobile.
However, style should still be somewhat adjusted to accomodate for UI bits Chrome adds (date doesn't fit in the box anymore).
