### PR TITLE
Add "maximum" arg to GET API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,7 +19,7 @@ Getting product feedback: GET /api/v1/feedback/
 
 
 Doing a GET without any querystring arguments will return the most
-recent 1000 publicly visible responses.
+recent 1,000 publicly visible responses for all products.
 
 .. Warning::
 
@@ -126,6 +126,19 @@ Filters
 
         # Shows 14 days starting 2014-08-12
         ?date_start=2014-08-12&date_delta=14d
+
+**max**
+
+    Integer. Defaults to 1,000. Maximum is 10,000. Minimum is 1. The maximum
+    number of responses you want to get back.
+
+    Example::
+
+        # Retrieve at most 500 responses
+        ?max=500
+
+        # Retrieve at most 10000 responses
+        ?max=10000
 
 
 Examples

--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -238,6 +238,24 @@ class PublicFeedbackAPITest(ElasticTestCase):
         eq_(sorted(json_data['results'][0].keys()),
             sorted(models.ResponseMappingType.public_fields()))
 
+    def test_max(self):
+        for i in range(10):
+            ResponseFactory(description=u'best browser ever %d' % i)
+        self.refresh()
+
+        resp = self.client.get(reverse('feedback-api'))
+        json_data = json.loads(resp.content)
+        eq_(json_data['count'], 10)
+
+        resp = self.client.get(reverse('feedback-api'), {'max': '5'})
+        json_data = json.loads(resp.content)
+        eq_(json_data['count'], 5)
+
+        # FIXME: For now, nonsense values get ignored.
+        resp = self.client.get(reverse('feedback-api'), {'max': 'foo'})
+        json_data = json.loads(resp.content)
+        eq_(json_data['count'], 10)
+
 
 class PostFeedbackAPITest(TestCase):
     def setUp(self):


### PR DESCRIPTION
This allows people to specify the maximum number of responses they want to get back. It defaults to 1,000. Maximum is 10,000. Minimum is 1.

r?
