### PR TITLE
[bug 788281] Document and tweak events api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,7 +16,7 @@ Getting product feedback: GET /api/v1/feedback/
 :URL:            ``/api/v1/feedback/``
 :Method:         HTTP GET
 :Payload format: There is no payload--everything is done in the querystring
-
+:Response format: JSON
 
 Doing a GET without any querystring arguments will return the most
 recent 1,000 publicly visible responses for all products.
@@ -417,6 +417,75 @@ HTTP 400
 HTTP 429
     There has been too many feedback postings from this IP address and
     the throttle trigger was hit. Try again later.
+
+
+Getting event data: /api/v1/events/
+===================================
+
+:URL:             ``/api/v1/events/``
+:Method:          HTTP GET
+:Payload format:  There is no payload--everything is done in the querystring
+:Response format: JSON
+
+Doing a GET without any querystring arguments will return all the event
+data.
+
+.. Note::
+
+   This API endpoint is still in flux. The documentation is
+   rudimentary at best. Amongst other things, it's difficult to
+   discover valid values for things.
+
+   If you're using this API endpoint and have issues, please
+   `open a bug
+   <https://bugzilla.mozilla.org/enter_bug.cgi?product=Input&rep_platform=all&op_sys=all&component=General>`_.
+
+.. Note::
+
+   The event data is pretty sparse at the moment and only contains
+   releases for Firefox and Firefox for Android. We plan to add to
+   this data.
+
+
+Filters
+-------
+
+**products**
+    Strings. Comma separated list of products. For valid products, see
+    `<https://input.mozilla.org/>`_.
+
+    Examples::
+
+        ?products=Firefox
+        ?products=Firefox,Firefox for Android
+
+**date_start**
+    Date in YYYY-MM-DD format. Specifies the start for the date range you're
+    querying for.
+
+    Example::
+
+        ?date_start=2014-08-12
+
+**date_end**
+    Date in YYYY-MM-DD format. Specifies the end for the date range you're
+    querying for.
+
+    Defaults to today.
+
+    Example::
+
+        ?date_end=2014-08-12
+
+
+Curl example
+------------
+
+Minimal example:
+
+::
+
+    curl -v https://input.mozilla.org/api/v1/events/?products=Firefox
 
 
 Posting heartbeat feedback: /api/v1/hb/

--- a/fjord/events/tests/test_views.py
+++ b/fjord/events/tests/test_views.py
@@ -1,0 +1,60 @@
+import json
+
+from fjord.base.tests import TestCase, reverse
+
+
+class EventAPITest(TestCase):
+    def test_root(self):
+        resp = self.client.get(reverse('event-api'))
+        json_data = json.loads(resp.content)
+
+        self.assertGreater(json_data['count'], 0)
+
+    def test_products_filter(self):
+        resp = self.client.get(reverse('event-api'))
+        json_data = json.loads(resp.content)
+
+        total_count = json_data['count']
+
+        resp = self.client.get(reverse('event-api') + '?products=Firefox')
+        json_data = json.loads(resp.content)
+
+        self.assertGreater(total_count, json_data['count'])
+
+    def test_date_start_filter(self):
+        resp = self.client.get(reverse('event-api'))
+        json_data = json.loads(resp.content)
+
+        total_count = json_data['count']
+
+        resp = self.client.get(reverse('event-api') + '?date_start=2014-09-01')
+        json_data = json.loads(resp.content)
+
+        self.assertGreater(total_count, json_data['count'])
+
+    def test_date_end_filter(self):
+        resp = self.client.get(reverse('event-api'))
+        json_data = json.loads(resp.content)
+
+        total_count = json_data['count']
+
+        resp = self.client.get(reverse('event-api') + '?date_end=2013-09-01')
+        json_data = json.loads(resp.content)
+
+        self.assertGreater(total_count, json_data['count'])
+
+    def test_invalid_date(self):
+        # FIXME: we should validate dates and then this would raise an
+        # error
+        resp = self.client.get(reverse('event-api') + '?date_start=omg')
+        json_data = json.loads(resp.content)
+
+        self.assertEquals(json_data['count'], 0)
+
+    def test_nonexistent_product(self):
+        # FIXME: we should validate product names and then this would
+        # raise an error
+        resp = self.client.get(reverse('event-api') + '?products=foo')
+        json_data = json.loads(resp.content)
+
+        self.assertEquals(json_data['count'], 0)

--- a/fjord/events/views.py
+++ b/fjord/events/views.py
@@ -9,27 +9,32 @@ class EventAPI(rest_framework.views.APIView):
     def get(self, request):
         events = get_product_details_history()
 
-        product = smart_str(request.GET.get('product'))
-        start_date = smart_str(request.GET.get('start_date'))
-        end_date = smart_str(request.GET.get('end_date'))
+        products = smart_str(request.GET.get('products'))
+        date_start = smart_str(request.GET.get('date_start'))
+        date_end = smart_str(request.GET.get('date_end'))
 
-        if product:
+        if products:
+            products = [prod.strip() for prod in products.split(',')]
             events = [event for event in events
-                      if event['product'] == product]
+                      if event['product'] in products]
 
-        if start_date:
+        if date_start:
             events = [event for event in events
-                      if event['date'] >= start_date]
+                      if event['date'] >= date_start]
 
-        if end_date:
+        if date_end:
             events = [event for event in events
-                      if event['date'] <= end_date]
+                      if event['date'] <= date_end]
 
         return rest_framework.response.Response({
+            'date_start': date_start if date_start else None,
+            'date_end': date_end if date_end else None,
+            'products': ','.join(products) if products else None,
             'count': len(events),
             'events': list(events)
         })
 
     def get_throttles(self):
-        # FIXME
+        # FIXME: At some point we should throttle use of this. We
+        # should probably do that as soon as it's hitting the db.
         return []


### PR DESCRIPTION
- change date filters to be consisten with other api end points
- change product filter to "products"
- document the events api
- add FIXMEs for things that should get fixed
- add some really basic tests for the API endpoint

r?
