### PR TITLE
[bug 1072575] Rework smart_timedelta

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -113,8 +113,8 @@ Filters
         ?date_end=2014-08-12
 
 **date_delta**
-    ``1d``, ``7d``, ``14d``. The number of days from ``date_start`` or
-    ``date_end``.
+    String. ``1d``, ``7d``, ``14d``, etc. The number of days from
+    ``date_start`` or ``date_end``.
 
     Example::
 
@@ -124,8 +124,8 @@ Filters
         # Shows 14 days ending 2014-08-12
         ?date_end=2014-08-12&date_delta=14d
 
-        # Shows 14 days starting 2014-08-12
-        ?date_start=2014-08-12&date_delta=14d
+        # Shows 22 days starting 2014-08-12
+        ?date_start=2014-08-12&date_delta=22d
 
 **max**
 

--- a/fjord/base/tests/test__util.py
+++ b/fjord/base/tests/test__util.py
@@ -14,6 +14,7 @@ from fjord.base.util import (
     smart_date,
     smart_int,
     smart_str,
+    smart_timedelta,
     smart_truncate
 )
 
@@ -105,6 +106,16 @@ class SmartBoolTest(TestCase):
             b = smart_bool(x, 'fallback')
             assert b == 'fallback', self.msg_template % (x, 'fallback', b)
 
+
+class SmartTimeDeltaTest(TestCase):
+    def test_valid(self):
+        eq_(smart_timedelta('1d'), datetime.timedelta(days=1))
+        eq_(smart_timedelta('14d'), datetime.timedelta(days=14))
+
+    def test_invalid(self):
+        eq_(smart_timedelta('0d', 'fallback'), 'fallback')
+        eq_(smart_timedelta('foo', 'fallback'), 'fallback')
+        eq_(smart_timedelta('d', 'fallback'), 'fallback')
 
 _foo_cache = {}
 

--- a/fjord/base/util.py
+++ b/fjord/base/util.py
@@ -162,14 +162,14 @@ def smart_timedelta(s, fallback=None):
     if isinstance(s, datetime.timedelta):
         return s
 
-    # FIXME: Doing this manually for now for specific deltas. We can
-    # figure out how we want this to operate in the future.
-    if s == '1d':
-        return datetime.timedelta(days=1)
-    if s == '7d':
-        return datetime.timedelta(days=7)
-    if s == '14d':
-        return datetime.timedelta(days=14)
+    if s and s.endswith('d'):
+        try:
+            days = int(s[:-1])
+            if days > 0:
+                return datetime.timedelta(days=days)
+        except ValueError:
+            pass
+
     return fallback
 
 


### PR DESCRIPTION
This changes smart_timedelta so that it handles any valid "int + 'd'"
value as long as the int is > 0.

It also adds tests.

Quick r?
