### PR TITLE
[bug 1079376] Add error-email -> response admin view

### DIFF
--- a/fjord/feedback/admin.py
+++ b/fjord/feedback/admin.py
@@ -1,5 +1,12 @@
-from django.contrib import admin
+import ast
+from urllib import urlencode
 
+from django.contrib import admin
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+
+from fjord.base.tests import LocalizingClient
 from fjord.feedback.models import Product, Response
 
 
@@ -53,3 +60,128 @@ class ResponseFeedbackAdmin(admin.ModelAdmin):
 
 admin.site.register(Product, ProductAdmin)
 admin.site.register(Response, ResponseFeedbackAdmin)
+
+
+def parse_data(data):
+    """Takes a string from a repr(WSGIRequest) and transliterates it
+
+    This is incredibly gross "parsing" code that takes the WSGIRequest
+    string from an error email and turns it into something that
+    vaguely resembles the original WSGIRequest so that we can send
+    it through the system again.
+
+    """
+    BEGIN = '<WSGIRequest'
+
+    data = data.strip()
+    data = data[data.find(BEGIN) + len(BEGIN):]
+    if data.endswith('>'):
+        data = data[:-1]
+
+    container = {}
+    key = ''
+    for line in data.splitlines():
+        # Lines that start with 'wsgi.' have values which are
+        # objects. E.g. a logger. This won't fly with ast.literal_eval
+        # so we just ignore all the wsgi. meta stuff.
+        if not line or line.startswith(' \'wsgi.'):
+            continue
+
+        if line.startswith(' '):
+            # If it starts with a space, then it's a continuation of
+            # the current dict.
+            container[key] += line
+        else:
+            key, val = line.split(':', 1)
+            container[key.strip()] = val.strip()
+
+    QUERYDICT = '<QueryDict: '
+
+    for key, val in container.items():
+        val = val.strip(',')
+
+        if val.startswith(QUERYDICT):
+            # GET and POST are both QueryDicts, so we nix the
+            # QueryDict part and pretend they're regular dicts.
+            #
+            # <QueryDict: {...}> -> {...}
+            val = val[len(QUERYDICT):-1]
+        elif val.startswith('{'):
+            # Regular dict that might be missing a } because we
+            # dropped it when we were weeding out wsgi. lines.
+            #
+            # {... -> {...}
+            val = val.strip()
+            if not val.endswith('}'):
+                val = val + '}'
+        else:
+            # This needs to have the string ornamentation added so it
+            # literal_evals into a string.
+            val = 'u"' + val + '"'
+
+        # Note: We use ast.literal_eval here so that we're guaranteed
+        # only to be getting out strings, lists, tuples, dicts,
+        # booleans or None and not executing arbitrary Python code.
+        val = ast.literal_eval(val)
+        container[key] = val
+
+    return container
+
+
+def generate_response(response_data):
+    """Takes a response data dict and generates a Response
+
+    This (ab)uses the LocalizingClient to do the work so that it goes
+    through all the existing view code which means I don't have to
+    duplicate all that stuff here.
+
+    """
+    client = LocalizingClient(enforce_csrf_checks=False)
+
+    url = response_data['path']
+    if response_data['GET']:
+        url = url + '?' + urlencode(response_data['GET'])
+
+    resp = client.post(
+        url,
+        data=response_data['POST'],
+        HTTP_USER_AGENT=response_data['META']['HTTP_USER_AGENT']
+    )
+    return resp
+
+
+def response_entry_view(request):
+    """OMG! THIS IS A CRAZY VIEW FOR CREATING RESPONSES FROM ERROR EMAILS!
+
+    DON'T LOOK! ABANDON ALL HOPE ALL WHO ENTER HERE!
+
+    This is an admin view so that we don't embarrass ourselves by
+    showing what we've done to others.
+
+    """
+    if request.method == 'POST':
+        data = request.POST['data']
+        if '<WSGIRequest' in data:
+            parsed_data = parse_data(data)
+            desc = parsed_data['POST']['description'][0]
+            resp = generate_response(parsed_data)
+            if resp.status_code in (200, 302):
+                feedback = (Response.objects
+                            .filter(description=desc)
+                            .latest('id'))
+                messages.success(request, 'Created id %s' % feedback.id)
+
+                return HttpResponseRedirect(request.path)
+            else:
+                messages.error(request, 'Raised: ' + str(resp.status_code))
+        else:
+            messages.error(
+                request,
+                'Cannot find "<WSGIRequest" in data. Try copy-and-pasting '
+                'again.')
+
+    return render(request, 'admin/response_entry.html')
+
+
+admin.site.register_view('response-entry-view', response_entry_view,
+                         'Response Entry')

--- a/fjord/feedback/templates/admin/response_entry.html
+++ b/fjord/feedback/templates/admin/response_entry.html
@@ -1,0 +1,37 @@
+{% extends "admin/base_site.html" %}
+{% block content_title %}
+  <h1>Response Entry</h1>
+{% endblock %}
+
+{% block content %}
+  <p>Copy and paste the WSGIRequest part of the error email here:</p>
+
+  <section>
+    <form method="POST">
+      {% csrf_token %}
+      <div>
+        <fieldset class="grp-module">
+          <div class="grp-row grp-cells-1">
+            <div class="l-2c-fluid l-d-4">
+              <div class="c-1">
+                <label for="id_data">WSGIRequest bits</label>
+              </div>
+              <div class="c-2">
+                <textarea class="vLargeTextField" id="id_data" name="data"></textarea>
+              </div>
+            </div>
+          </div>
+          <div class="grp-row grp-cells-1">
+            <div class="1-2c-fluid 1-d-4">
+              <div class="c-1">&nbsp;</div>
+              <div class="c-2">
+        	    <input type="submit" value="Generate response" class="grp-button grp-default" name="_save" />
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </form>
+  </section>
+
+{% endblock %}


### PR DESCRIPTION
This adds an admin view that lets me add feedback that errored out when
it was posting to Input by relevant part of the copy-and-pasting the
error email. This is a stopgap until Input has 5 9s.

r?
