### PR TITLE
[bug 1020303] Add rating column

### DIFF
--- a/fjord/feedback/migrations/0031_auto__add_field_response_rating.py
+++ b/fjord/feedback/migrations/0031_auto__add_field_response_rating.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Response.rating'
+        db.add_column(u'feedback_response', 'rating',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Response.rating'
+        db.delete_column(u'feedback_response', 'rating')
+
+
+    models = {
+        u'feedback.product': {
+            'Meta': {'object_name': 'Product'},
+            'db_name': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'on_dashboard': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'translation_system': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'api': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'campaign': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'rating': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('fjord.base.models.EnhancedURLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        u'feedback.responsecontext': {
+            'Meta': {'object_name': 'ResponseContext'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': "u'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -106,6 +106,7 @@ class Response(ModelBase):
     response was created:
 
     * happy
+    * rating
     * url
     * description
     * user_agent
@@ -117,6 +118,7 @@ class Response(ModelBase):
 
     # Data coming from the user
     happy = models.BooleanField(default=True)
+    rating = models.PositiveIntegerField(null=True)
     url = EnhancedURLField(blank=True)
     description = models.TextField(blank=True)
 
@@ -271,6 +273,8 @@ class Response(ModelBase):
 
     def save(self, *args, **kwargs):
         self.description = self.description.strip()[:TRUNCATE_LENGTH]
+        if self.rating is not None:
+            self.happy = False if self.rating <= 3 else True
         super(Response, self).save(*args, **kwargs)
 
     @property

--- a/fjord/feedback/tests/test_models.py
+++ b/fjord/feedback/tests/test_models.py
@@ -43,6 +43,31 @@ class TestResponseModel(TestCase):
         eq_(resp.url_domain, u'\u30c9\u30e9\u30af\u30a810.jp')
         assert isinstance(resp.url_domain, unicode)
 
+    def test_rating_to_happy(self):
+        """Test that we do populate happy from rating"""
+        data = {
+            1: False,
+            2: False,
+            3: False,
+            4: True,
+            5: True
+        }
+        for rat, expected in data.items():
+            # Create the response, but DON'T save it to the db.
+            resp = ResponseFactory.build(happy=None, rating=rat)
+            resp.save()
+            eq_(resp.happy, expected)
+
+    def test_happy_to_rating(self):
+        """Test we don't populate rating from happy"""
+        resp = ResponseFactory.build(happy=True, rating=None)
+        resp.save()
+        eq_(resp.rating, None)
+
+        resp = ResponseFactory.build(happy=False, rating=None)
+        resp.save()
+        eq_(resp.rating, None)
+
 
 class TestAutoTranslation(TestCase):
     def setUp(self):


### PR DESCRIPTION
This adds a rating column which is like the happy column, but allows for
a gradation of values.

If we get a response with a rating, but no happy, then we'll populate
the happy accordingly--we always want to have a happy.

However, if we get a happy, but no rating, we won't populate the rating
column--we'll leave it null.

This allows us to A/B test the two and distinguish between which version
of the form the user saw and correlate that to the answer they gave.

r?
