### PR TITLE
[bug 940361] Change size on facet calls

### DIFF
--- a/fjord/analytics/analyzer_views.py
+++ b/fjord/analytics/analyzer_views.py
@@ -121,7 +121,6 @@ def analytics_occurrences(request):
                 # in the backend.
                 first_params['date_start'] = '2013-01-01'
 
-            # Have to do raw because we want a size > 10.
             first_resp_s = first_resp_s.facet('description_bigrams',
                                               size=30, filtered=True)
             first_resp_s = first_resp_s[0:0]
@@ -480,8 +479,8 @@ def analytics_search(request):
         'organic': {},
     }
     facets = search.facet(*(counts.keys()),
-                          filtered=bool(search._process_filters(f.filters)),
-                          size=25)
+                          size=1000,
+                          filtered=bool(search._process_filters(f.filters)))
 
     for param, terms in facets.facet_counts().items():
         for term in terms:

--- a/fjord/analytics/views.py
+++ b/fjord/analytics/views.py
@@ -322,6 +322,7 @@ def dashboard(request):
     # Navigation facet data
     facets = search.facet(
         'happy', 'platform', 'locale', 'product', 'version',
+        size=1000,
         filtered=bool(search._process_filters(f.filters)))
 
     # This loop does two things. First it maps 'T' -> True and 'F' ->


### PR DESCRIPTION
The default size is 10. When we use that number, we get "inaccurate"
facet counts:

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html#_accuracy_control

This increases the size to 1000 which should make it more accurate and
thus the counts between two different pages should be the same.

r?
