### PR TITLE
[bug 1094197] Fix JSONObjectField default default

### DIFF
--- a/fjord/base/models.py
+++ b/fjord/base/models.py
@@ -56,6 +56,14 @@ class JSONObjectField(models.TextField):
     empty_strings_allowed = False
     description = _lazy(u'JSON Object')
 
+    def __init__(self, *args, **kwargs):
+        # "default" should default to an empty JSON dict. We implement
+        # that this way rather than getting involved in the
+        # get_default/has_default Field machinery since this makes it
+        # easier to subclass.
+        kwargs['default'] = kwargs.get('default', u'{}')
+        super(JSONObjectField, self).__init__(self, *args, **kwargs)
+
     def pre_init(self, value, obj):
         if obj._state.adding:
             if isinstance(value, basestring):

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -537,7 +537,7 @@ class ResponseContext(ModelBase):
     """Holds context data we were sent as a JSON blob."""
 
     opinion = models.ForeignKey(Response)
-    data = JSONObjectField(default=u'{}')
+    data = JSONObjectField()
 
     def __unicode__(self):
         return unicode(self.id)

--- a/fjord/journal/models.py
+++ b/fjord/journal/models.py
@@ -77,7 +77,7 @@ class Record(ModelBase):
 
     # Any metadata related to this entry in the form of a Python dict which
     # is stored as a JSON object
-    metadata = JSONObjectField(default=u'{}')
+    metadata = JSONObjectField()
 
     # Note: This doesn't use django-cache-machine. These objects are
     # mostly for site maintenance purposes and thus we don't really


### PR DESCRIPTION
This fixes the default so that it's always u'{}'. It can be overridden,
so mostly this just codifies the default so we don't have to keep typing
it across the codebase.

r?
