### PR TITLE
[bug 1097352] Response view is viewable by all

### DIFF
--- a/fjord/analytics/tests/test_views.py
+++ b/fjord/analytics/tests/test_views.py
@@ -411,38 +411,6 @@ class TestResponseview(ElasticTestCase):
         self.assertTemplateUsed(r, 'analytics/mobile/response.html')
         assert str(resp.description) in r.content
 
-    def test_hidden_products_with_unauthed_user(self):
-        prod = ProductFactory(display_name='HiddenProduct', on_dashboard=False)
-        resp = ResponseFactory(product=prod.db_name)
-        self.refresh()
-
-        r = self.client.get(reverse('response_view', args=(resp.id,)))
-        eq_(403, r.status_code)
-
-    def test_hidden_products_with_authed_user(self):
-        prod = ProductFactory(display_name='HiddenProduct', on_dashboard=False)
-        resp = ResponseFactory(product=prod.db_name)
-        self.refresh()
-
-        jane = ProfileFactory(user__email='jane@example.com').user
-        self.client_login_user(jane)
-
-        r = self.client.get(reverse('response_view', args=(resp.id,)))
-        eq_(403, r.status_code)
-
-    def test_hidden_products_with_analyzer_user(self):
-        prod = ProductFactory(display_name='HiddenProduct', on_dashboard=False)
-        resp = ResponseFactory(product=prod.db_name)
-        self.refresh()
-
-        jane = ProfileFactory(user__email='jane@example.com').user
-        jane.groups.add(Group.objects.get(name='analyzers'))
-
-        self.client_login_user(jane)
-
-        r = self.client.get(reverse('response_view', args=(resp.id,)))
-        eq_(200, r.status_code)
-
     def test_response_view_analyzer(self):
         """Test secret section only shows up for analyzers"""
         resp = ResponseFactory(happy=True, description=u'the bestest best!')

--- a/fjord/analytics/views.py
+++ b/fjord/analytics/views.py
@@ -8,7 +8,6 @@ from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.http import (
     HttpResponse,
-    HttpResponseForbidden,
     HttpResponseRedirect
 )
 from django.shortcuts import get_object_or_404, render
@@ -65,21 +64,6 @@ def spot_translate(request, responseid):
 @mobile_template('analytics/{mobile/}response.html')
 def response_view(request, responseid, template):
     response = get_object_or_404(Response, id=responseid)
-
-    try:
-        prod = Product.objects.get(db_name=response.product)
-
-        if (not prod.on_dashboard
-                and (not request.user.is_authenticated()
-                     or not request.user.has_perm(
-                         'analytics.can_view_dashboard'))):
-
-            # If this is a response for a hidden product and the user
-            # isn't in the analytics group, then they can't see it.
-            return HttpResponseForbidden()
-
-    except Product.DoesNotExist:
-        pass
 
     mlt = None
     records = None


### PR DESCRIPTION
Previosuly, we were using the Product on_dashboard flag to cover the
response view as well. Bug 1097352 covers adjusting that thinking so
that the on_dashboard flag literally just dictates whether it shows up
on the front page dashboard and doesn't affect permalinks. It will add
finer-grained public/private flags.

This fixes the response view to allow all responses be public. We'll do
the rest of the work for bug 1097352 later.

r?
