### PR TITLE
Fix JSONObjectField

### DIFF
--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -375,7 +375,7 @@ class PostFeedbackAPITest(TestCase):
         eq_(r.status_code, 201)
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, u'{"slopmenow": "bar"}')
+        eq_(context.data, {'slopmenow': 'bar'})
 
     def test_with_context_truncate_key(self):
         data = {
@@ -394,7 +394,7 @@ class PostFeedbackAPITest(TestCase):
         eq_(r.status_code, 201)
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, u'{"foo01234567890123456": "bar"}')
+        eq_(context.data, {'foo01234567890123456': 'bar'})
 
     def test_with_context_truncate_value(self):
         data = {
@@ -413,7 +413,7 @@ class PostFeedbackAPITest(TestCase):
         eq_(r.status_code, 201)
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, u'{"foo": "' + ('a' * 100) + '"}')
+        eq_(context.data, {'foo': ('a' * 100)})
 
     def test_with_context_20_pairs(self):
         data = {
@@ -434,7 +434,7 @@ class PostFeedbackAPITest(TestCase):
         eq_(r.status_code, 201)
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        data = sorted(json.loads(context.data).items())
+        data = sorted(context.data.items())
         eq_(len(data), 20)
         eq_(data[0], ('foo00', '0'))
         eq_(data[-1], ('foo19', '19'))

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.cache import cache
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -539,7 +537,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, u'{"foo": "bar"}')
+        eq_(context.data, {'foo': 'bar'})
 
     def test_save_context_long_key(self):
         """Long keys are truncated"""
@@ -553,7 +551,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, u'{"foo12345678901234567": "bar"}')
+        eq_(context.data, {'foo12345678901234567': 'bar'})
 
     def test_save_context_long_val(self):
         """Long values are truncated"""
@@ -567,7 +565,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, u'{"foo": "' + ('a' * 100) + '"}')
+        eq_(context.data, {'foo': ('a' * 100)})
 
     def test_save_context_maximum_pairs(self):
         """Only save 20 pairs"""
@@ -583,7 +581,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        data = sorted(json.loads(context.data).items())
+        data = sorted(context.data.items())
         eq_(len(data), 20)
         eq_(data[0], (u'foo00', '0'))
         eq_(data[-1], (u'foo19', '19'))


### PR DESCRIPTION
When pulling data from the db, the JSONObjectField values weren't being
correctly converted back to Python types. Thus you couldn't save some
data, then later pull it out, add to it and put it back in.

This fixes that and tests that were testing against the wrong values.

This fixes some dumb stuff I did. It doesn't seem to affect existing db stuff,
but rather just fixes things coming out of the db.

r?
