### PR TITLE
[bug 1087387, bug 1096541] Clean up feedback view code

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -333,6 +333,7 @@ class Response(ModelBase):
 
     @classmethod
     def infer_product(cls, platform):
+        # FIXME: This is hard-coded.
         if platform == u'Firefox OS':
             return u'Firefox OS'
 
@@ -343,6 +344,23 @@ class Response(ModelBase):
             return u''
 
         return u'Firefox'
+
+    @classmethod
+    def infer_platform(cls, product, browser):
+        # FIXME: This is hard-coded.
+        if product == u'Firefox OS':
+            return u'Firefox OS'
+
+        elif product == u'Firefox for Android':
+            return u'Android'
+
+        elif (browser.browser == u'Firefox' and
+              product in (u'Firefox', u'Firefox dev')):
+            if browser.platform == 'Windows':
+                return browser.platform + ' ' + browser.platform_version
+            return browser.platform
+
+        return u''
 
 
 @register_mapping_type


### PR DESCRIPTION
- clean up the feedback view code, nixes silly code
- fix product/version/channel/platform inference code to be smarter and
  more correct
- set browser_platform where appropriate
- add tests for everything

Note: This hardcodes "Firefox dev" test which fixes the bug. However, we
should fix Response infer_\* methods so they're using Product information
instead of being hard-coded. That's a project for a different bug....

r?
