### PR TITLE
[bug 1103024] Gengo kill switch

### DIFF
--- a/fjord/base/migrations/0005_create_gengo_switch.py
+++ b/fjord/base/migrations/0005_create_gengo_switch.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Remember to use orm['appname.ModelName'] rather than "from appname.models..."
+        Switch = orm['waffle.switch']
+        switch = Switch(
+            name='gengosystem',
+            note='Enables/disables Gengo API usage',
+            active=True
+        )
+        switch.save()
+
+    def backwards(self, orm):
+        Switch = orm['waffle.switch']
+        try:
+            switch = Switch.objects.get(name='gengosystem')
+            switch.delete()
+        except Switch.DoesNotExist:
+            pass
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'base.profile': {
+            'Meta': {'object_name': 'Profile'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'waffle.flag': {
+            'Meta': {'object_name': 'Flag'},
+            'authenticated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'everyone': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'percent': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '3', 'decimal_places': '1', 'blank': 'True'}),
+            'rollout': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'superusers': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'testing': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'waffle.sample': {
+            'Meta': {'object_name': 'Sample'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'percent': ('django.db.models.fields.DecimalField', [], {'max_digits': '4', 'decimal_places': '1'})
+        },
+        u'waffle.switch': {
+            'Meta': {'object_name': 'Switch'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['waffle', 'base']
+    symmetrical = True

--- a/fjord/translations/models.py
+++ b/fjord/translations/models.py
@@ -8,6 +8,7 @@ from django.db import models
 
 from dennis.translator import Translator
 from statsd import statsd
+import waffle
 
 from .gengo_utils import (
     FjordGengo,
@@ -190,6 +191,11 @@ class GengoMachineTranslator(TranslationSystem):
     name = 'gengo_machine'
 
     def translate(self, instance, src_lang, src_field, dst_lang, dst_field):
+        # If gengosystem is disabled, we just return immediately. We
+        # can backfill later.
+        if not waffle.switch_is_active('gengosystem'):
+            return
+
         text = getattr(instance, src_field)
         metadata = {
             'locale': instance.locale,
@@ -426,6 +432,11 @@ class GengoHumanTranslator(TranslationSystem):
     use_push_and_pull = True
 
     def translate(self, instance, src_lang, src_field, dst_lang, dst_field):
+        # If gengosystem is disabled, we just return immediately. We
+        # can backfill later.
+        if not waffle.switch_is_active('gengosystem'):
+            return
+
         text = getattr(instance, src_field)
         metadata = {
             'locale': instance.locale,
@@ -550,6 +561,11 @@ class GengoHumanTranslator(TranslationSystem):
             )
 
     def push_translations(self):
+        # If gengosystem is disabled, we just return immediately. We
+        # can backfill later.
+        if not waffle.switch_is_active('gengosystem'):
+            return
+
         gengo_api = FjordGengo()
 
         if not gengo_api.is_configured():
@@ -614,6 +630,11 @@ class GengoHumanTranslator(TranslationSystem):
                 return
 
     def pull_translations(self):
+        # If gengosystem is disabled, we just return immediately. We
+        # can backfill later.
+        if not waffle.switch_is_active('gengosystem'):
+            return
+
         gengo_api = FjordGengo()
 
         if not gengo_api.is_configured():


### PR DESCRIPTION
Periodically, Gengo does system maintenance and during this period they
don't want anyone doing API calls or creating translation jobs.

This creates a waffle switch that allows us to enable/disable all
Gengo-related activities across the site. If gengosystem switch is
disabled, we don't do any translations, pushes or pulls.

We're going for simplicity here. Thus the thing this doesn't cover is
what happens to all the things that _should_ have been translated during
that time. For that, we have the backfill tool which is available in the
admin in the "Translations - Gengo Maintenance" view.

r?
