### PR TITLE
[bug 1103167] Raise GET API throttle

### DIFF
--- a/fjord/feedback/api_views.py
+++ b/fjord/feedback/api_views.py
@@ -104,8 +104,8 @@ class PublicFeedbackAPI(rest_framework.views.APIView):
         """Returns throttle class instances"""
         return [
             RatelimitThrottle(
-                rulename='api_get_100ph',
-                rate='100/h',
+                rulename='api_get_200ph',
+                rate='200/h',
                 methods=('GET',))
         ]
 


### PR DESCRIPTION
This raises the throttle to 200ph.

Note: This is another arbitrarily chosen number, but this one is larger
than the previously arbitrarily chosen number. Next time we think about
raising it, we should look at usage patterns.

Super quick r?
