### PR TITLE
[bug 1107809] Fix Gengo language guesser

### DIFF
--- a/fjord/translations/gengo_utils.py
+++ b/fjord/translations/gengo_utils.py
@@ -189,7 +189,7 @@ class FjordGengo(object):
         # get_language is a "private API" thing Gengo has, so it's not
         # included in the gengo library and we have to do it manually.
         resp = requests.post(
-            'http://api2.gengo.com/api/service/detect/language',
+            'https://api.gengo.com/service/detect_language',
             data=json.dumps({'text': text.encode('utf-8')}),
             headers={
                 'Content-Type': 'application/json',
@@ -198,7 +198,7 @@ class FjordGengo(object):
 
         resp_json = resp.json()
 
-        if resp_json['opstat'] == 'ok':
+        if 'detected_lang_code' in resp_json:
             lang = resp_json['detected_lang_code']
             if lang == 'un':
                 raise GengoUnknownLanguage('unknown language')


### PR DESCRIPTION
On Thursday, Gengo did a massive API update and in the process the
unofficial language guesser API endpoint we were using disappeared.

This updates the url to the correct url, tweaks the code to handle the
new response shape and switches us to use HTTPS.

r?
