### PR TITLE
[bug 1107083] Rewrite Response inference code

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -340,7 +340,9 @@ class Response(ModelBase):
         return ResponseMappingType
 
     @classmethod
-    def infer_product(cls, platform):
+    def infer_product(cls, browser):
+        platform = browser.platform
+
         # FIXME: This is hard-coded.
         if platform == u'Firefox OS':
             return u'Firefox OS'

--- a/fjord/feedback/tests/__init__.py
+++ b/fjord/feedback/tests/__init__.py
@@ -44,7 +44,7 @@ class ResponseFactory(factory.DjangoModelFactory):
 
     product = factory.LazyAttribute(
         lambda a: Response.infer_product(
-            browsers.parse_ua(a.user_agent).platform))
+            browsers.parse_ua(a.user_agent)))
     channel = u'stable'
     version = factory.LazyAttribute(
         lambda a: browsers.parse_ua(a.user_agent).browser_version)


### PR DESCRIPTION
Pretty sure there were some edge cases where we wouldn't infer data that
was appropriate to infer. This reworks the code to read better so it's
easier to reason about all the possible cases including the ones we
weren't handling well before.

I also nixed the code that sets the channel. It's not really appropriate
to assume everything is "stable" if no value is provided. Not sure why I
thought that was a hawt idea before.

r?
