### PR TITLE
Fix bug "1074315 -  fix bin/flake8_lint.sh script to not try to lint files that don't exist"

### DIFF
--- a/bin/hooks/flake8_lint.pre-commit
+++ b/bin/hooks/flake8_lint.pre-commit
@@ -9,7 +9,7 @@ DIR=$(dirname $0)
 
 function lint() {
     echo 'Linting...'
-    FILES_TO_LINT=$(git diff-index --no-commit-id --name-only -r HEAD | sort | uniq)
+    FILES_TO_LINT=$(git diff-index --no-commit-id --name-status -r HEAD | sort | grep -v '^D' | uniq | awk '{print $2}')
     ./bin/flake8_lint.sh $FILES_TO_LINT
     LINT_STATUS=$?
     if [[ $LINT_STATUS -ne 0 ]]; then


### PR DESCRIPTION
Use mythmon's fix for this issue in kitsune repository from
https://github.com/mozilla/kitsune/pull/2252
