### PR TITLE
Get list of .py files to lint using just git diff

### DIFF
--- a/bin/hooks/flake8_lint.pre-commit
+++ b/bin/hooks/flake8_lint.pre-commit
@@ -9,7 +9,7 @@ DIR=$(dirname $0)
 
 function lint() {
     echo 'Linting...'
-    FILES_TO_LINT=$(git diff-index --no-commit-id --name-status -r HEAD | sort | grep -v '^D' | uniq | awk '{print $2}')
+    FILES_TO_LINT=$(git diff --cached --name-only --diff-filter=ACMR -- *.py **/*.py)
     ./bin/flake8_lint.sh $FILES_TO_LINT
     LINT_STATUS=$?
     if [[ $LINT_STATUS -ne 0 ]]; then


### PR DESCRIPTION
Instead of using series of commands connected by pipes to get a list of modified files with status and name, exclude the deleted files and then print just the name, --diff-filter option of git diff command can be used to do it in a concise way
