### PR TITLE
[WIP] Add jshint to pre-commit hook

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+!(*.js)
+vendor/
+node_modules/

--- a/bin/hooks/lint.pre-commit
+++ b/bin/hooks/lint.pre-commit
@@ -7,10 +7,9 @@
 
 DIR=$(dirname $0)
 
-function lint() {
-    echo 'Linting...'
-    FILES_TO_LINT=$(git diff --cached --name-only --diff-filter=ACMR -- *.py **/*.py)
-    ./bin/flake8_lint.sh $FILES_TO_LINT
+function flake8_lint() {
+    PY_FILES_TO_LINT=$(git diff --cached --name-only --diff-filter=ACMR -- *.py **/*.py)
+    ./bin/flake8_lint.sh $PY_FILES_TO_LINT
     LINT_STATUS=$?
     if [[ $LINT_STATUS -ne 0 ]]; then
         echo
@@ -18,6 +17,24 @@ function lint() {
         echo "Alternatively, run 'git commit --no-verify' to ignore lint errors."
         exit 1
     fi
+}
+
+function jshint_lint() {
+    JS_FILES_TO_LINT=$(git diff --cached --name-only --diff-filter=ACMR -- *.js **/*.js)
+    jshint $JS_FILES_TO_LINT
+    LINT_STATUS=$?
+    if [[ $LINT_STATUS -ne 0 ]]; then
+        echo
+        echo "Lint errors found. Please fix the above and retry."
+        echo "Alternatively, run 'git commit --no-verify' to ignore lint errors."
+        exit 1
+    fi
+}
+
+function lint() {
+    echo 'Linting...'
+    flake8_lint
+    jshint_lint
 }
 
 function install() {
@@ -37,7 +54,7 @@ function install() {
         exit 1
     fi
 
-    ln -s ../../bin/hooks/flake8_lint.pre-commit $GITDIR/hooks/pre-commit
+    ln -s ../../bin/hooks/lint.pre-commit $GITDIR/hooks/pre-commit
 }
 
 if echo $DIR | grep -E ".git/hooks$" > /dev/null; then

--- a/bin/vagrant_provision.sh
+++ b/bin/vagrant_provision.sh
@@ -22,8 +22,8 @@ apt-get install -y -q npm
 # Homogenize binary name with production RHEL:
 ln -sf /usr/bin/nodejs /usr/local/bin/node
 
-# Install LESSC
-npm install -g less
+# Install node modules from package.json
+sudo -H -u vagrant npm install
 
 # Install Python development-related things:
 apt-get install -y -q libapache2-mod-wsgi python-pip libpython-dev
@@ -84,6 +84,9 @@ apt-get autoremove -y -q
 
 # Activate the virtual environment in .bashrc
 echo ". $VENV/bin/activate" >> /home/vagrant/.bashrc
+
+# Add the 'bin' folder of local node modules to $PATH
+echo "export PATH=$PATH:/home/vagrant/fjord/node_modules/.bin/" >> /home/vagrant/.bashrc
 
 # FIXME: Change the motd file so that it has a link to Fjord docs,
 # tells the user where the code is and lists common commands.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "Fjord",
+    "description": "Platform for Mozilla Input",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/mozilla/fjord.git"
+    },
+    "devDependencies": {
+        "jshint": "2.5.10"
+    },
+    "dependencies": {
+        "less": "1.7.0"
+    }
+
+}


### PR DESCRIPTION
Summary of changes:
- Define the node modules to be installed in package.json.
- Include 'jshint' as a dev dependency and 'less' as a
  dependency. 'less' is no longer installed globally.
- Since jshint doesn't include non-JavaScript files, specify the files and
  folders to be ignored in .jshintignore file.
- Install the node modules defined in package.json while provisioning.
- Add the node_modules/.bin/ folder to $PATH in ~/.bashrc.
- Create a wrapper script on top of jshint for JavaScript lint
- Modify the pre-commit script to use the wrapper script on the
  JavaScript files to be committed.
