### PR TITLE
[bug 1111265] Restrict remote-troubleshooting to Firefox

### DIFF
--- a/fjord/feedback/templates/feedback/generic_feedback.html
+++ b/fjord/feedback/templates/feedback/generic_feedback.html
@@ -136,8 +136,9 @@
               <input class="url" id="id_url" name="url" placeholder="http://" type="text">
             </div>
 
-            {% if waffle.flag('feedbackdev') and LANG == 'en-US' %}
+            {% if waffle.flag('feedbackdev') and LANG == 'en-US' and product.display_name == 'Firefox' %}
               {# NOTE: en-US only until we're sure it's good and translations are done. #}
+              {# NOTE: "Firefox" only until we figure out how to deal with browser/product mismatches. #}
               <div id="browser-ask" class="private">
                 <div class="ask">
                   <input id="browser-ok" name="browser_ok" type="checkbox">


### PR DESCRIPTION
If there's a mismatch between the product the user is leaving feedback
about and the browser the user is using, then we really don't want the
browser data. I haven't figured out how to programmatically figure that
out in a general way, yet.

In the meantime, we're going to restrict this to Firefox product only
because that's where we get the best bang for our buck right now anyhow.

r?
