### PR TITLE
Disable expansion of $PATH in the provisioning script

### DIFF
--- a/bin/vagrant_provision.sh
+++ b/bin/vagrant_provision.sh
@@ -86,7 +86,7 @@ apt-get autoremove -y -q
 echo ". $VENV/bin/activate" >> /home/vagrant/.bashrc
 
 # Add the 'bin' folder of local node modules to $PATH
-echo "export PATH=$PATH:/home/vagrant/fjord/node_modules/.bin/" >> /home/vagrant/.bashrc
+echo "export PATH=\$PATH:/home/vagrant/fjord/node_modules/.bin/" >> /home/vagrant/.bashrc
 
 # FIXME: Change the motd file so that it has a link to Fjord docs,
 # tells the user where the code is and lists common commands.


### PR DESCRIPTION
The $PATH value in the provisioning script was getting expanded
before being written into the ~/.bashrc file. This lead to the
path modifications done by the virtualenv activate script to be
overwritten. Escaping it properly avoids this issue.
