### PR TITLE
[bug 1087395] Add fields to CSV output

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -271,6 +271,9 @@ class Response(ModelBase):
             'manufacturer',
             'device',
             'platform',
+            'browser',
+            'browser_version',
+            'browser_platform',
         ]
 
         if confidential:


### PR DESCRIPTION
I added 'browser', 'browser_version', and 'browser_platform' to the get_export_keys() class method. In manual testing they fields show up between the "platform" and "url" fields.
