### PR TITLE
[bug 1110543] Add noscript section

### DIFF
--- a/fjord/feedback/templates/feedback/generic_feedback.html
+++ b/fjord/feedback/templates/feedback/generic_feedback.html
@@ -44,6 +44,14 @@
         <div class="card" id="intro" data-title="{{ _('{product} feedback')|fe(product=product.display_name) }}">
           <section>
             <div class="ask">
+              <noscript>
+                <p class="error">
+                  {% trans %}
+                    JavaScript is required to leave feedback. Please enable JavaScript in your browser and refresh this page.
+                  {% endtrans %}
+                </p>
+              </noscript>
+              
               {% trans product=product.display_name %}
                 How does {{product}} make you feel?
               {% endtrans %}

--- a/fjord/feedback/templates/feedback/picker.html
+++ b/fjord/feedback/templates/feedback/picker.html
@@ -32,6 +32,14 @@
             <p class="no-products">{{ _('No products available.') }}</p>
           {% else %}
             <div class="ask">
+              <noscript>
+                <p class="error">
+                  {% trans %}
+                    JavaScript is required to leave feedback. Please enable JavaScript in your browser and refresh this page.
+                  {% endtrans %}
+                </p>
+              </noscript>
+
               {% trans %}
                 Select a product to leave feedback for.
               {% endtrans %}


### PR DESCRIPTION
Adding the <noscript> section to both the generic_feedback.html and picker.html templates allows the message to stay displayed when the user picks a product without JavaScript being enabled.
