### PR TITLE
[bug 1116543] Peg pip at 1.5.6

### DIFF
--- a/bin/vagrant_provision.sh
+++ b/bin/vagrant_provision.sh
@@ -54,6 +54,12 @@ VENV=/home/vagrant/.virtualenvs/fjordvagrant
 # Build virtual environment and activate it
 sudo -H -u vagrant virtualenv $VENV
 
+# FIXME: This is here to deal with the fact that our version of peep
+# doesn't work so hot with recent versions of pip. We can remove this
+# when peep is fixed.
+# Install a version of pip that works with peep.
+sudo -H -u vagrant $VENV/bin/pip install pip==1.5.6
+
 # Install Fjord requirements
 sudo -H -u vagrant $VENV/bin/python ./peep install -r requirements/requirements.txt
 


### PR DESCRIPTION
pip 1.5.6 works with the version of peep we have. We peg pip at 1.5.6 so
that vagrant provisioning works correctly.

We can unpeg this when peep works with the latest version of pip which
is like 1.6.something.

r?
