### PR TITLE
[bug 1091716] Allow about: and chrome:// URLs in client-side validation

### DIFF
--- a/fjord/base/static/js/fjord_utils.js
+++ b/fjord/base/static/js/fjord_utils.js
@@ -106,13 +106,18 @@ window.fjord = window.fjord || {};
     * @returns {boolean}
     */
     fjord.validateUrl = function(url) {
-        var urlRegExp = /^((ftp|http|https):\/\/)?(\w+:{0,1}\w*@)?(\S+\.\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
-        if (url.length > 0 && !url.match(urlRegExp)) {
-            return false;
+        if (url.length > 0) {
+            var aboutUrlRegExp = /^about:/;
+            var chromeUrlRegExp = /^chrome:\/\//;
+            var urlRegExp = /^((ftp|http|https):\/\/)?(\w+:{0,1}\w*@)?(\S+\.\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
+
+            if (urlRegExp.test(url) ||
+                    aboutUrlRegExp.test(url) ||
+                    chromeUrlRegExp.test(url)) {
+                return true;
+            }
         }
-        else {
-            return true;
-        }
+        return false;
     };
 
     /**

--- a/fjord/base/static/tests/test_fjord_utils.js
+++ b/fjord/base/static/tests/test_fjord_utils.js
@@ -19,10 +19,11 @@ test("basic url validation", function() {
     var i;
     var test_data = [
         ['a', false],
-        ['about:start', false],
-        ['chrome://somepage', false],
+        ['about:start', true],
+        ['chrome://somepage', true],
         ['http://example', false],
-        ['', true],
+        ['', false],
+        [' www.google.com ', false],
         ['example.com', true],
         ['ftp://example.com', true],
         ['http://example.com', true],
@@ -46,7 +47,7 @@ test("basic format test", function() {
         ["Hello {1}", ['Adam', 'World'], 'Hello World'],
         ['{y}', {x: 1, y: 2}, '2']
     ];
-    
+
     for (i=0; i < test_data.length; i++) {
         var item = test_data[i];
         equal(fjord.format(item[0], item[1]), item[2]);

--- a/fjord/feedback/static/js/generic_feedback.js
+++ b/fjord/feedback/static/js/generic_feedback.js
@@ -63,7 +63,8 @@
         });
 
         $('#id_url').on('input', function() {
-            if (fjord.validateUrl($(this).val())) {
+            url = $.trim($(this).val());
+            if (fjord.validateUrl(url) || !url.length) {
                 $(this).removeClass('invalid');
             } else {
                 $(this).addClass('invalid');

--- a/fjord/feedback/static/js/generic_feedback.js
+++ b/fjord/feedback/static/js/generic_feedback.js
@@ -40,10 +40,10 @@
         function toggleSubmitButton() {
             var isValid = true;
 
-            if ($('#description').val().replace(/^\s+/, '') === ''
-                    || $('#description').hasClass('invalid')
-                    || $('#id_url').hasClass('invalid')
-                    || $('#id_email').hasClass('invalid')) {
+            if ($('#description').val().replace(/^\s+/, '') === '' ||
+                    $('#description').hasClass('invalid') ||
+                    $('#id_url').hasClass('invalid') ||
+                    $('#id_email').hasClass('invalid')) {
                 isValid = false;
             }
 


### PR DESCRIPTION
While performing client-side validation of a URL, allow about: and
chrome:// URLs. Similar fix on the server side has already been done
as a part of fixing bug 1057617.