### PR TITLE
Handle whitespace URLs

### DIFF
--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -514,6 +514,17 @@ class TestFeedback(TestCase):
         feedback = models.Response.objects.latest(field_name='id')
         eq_(feedback.url, u'http://mozilla.org/path/')
 
+    def test_url_leading_trailing_whitespace_removal(self):
+        """Leading/trailing whitespace in urls is stripped"""
+        url = reverse('feedback', args=(u'firefox',))
+        self.client.post(url, {
+            'url': u'   \t\n\r',
+            'happy': 0,
+            'description': u'foo'
+        })
+        feedback = models.Response.objects.latest(field_name='id')
+        eq_(feedback.url, u'')
+
     def test_email_collection(self):
         """If the user enters an email and checks the box, collect email."""
         url = reverse('feedback', args=(u'firefox',))

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -110,7 +110,7 @@ def _handle_feedback_post(request, locale=None, product=None,
     opinion = models.Response(
         # Data coming from the user
         happy=data['happy'],
-        url=clean_url(data.get('url', u'')),
+        url=clean_url(data.get('url', u'').strip()),
         description=description,
 
         # Pulled from the form data or the url


### PR DESCRIPTION
If a URL consists solely of whitespace, we should strip the whitespace
and store an empty string in the db.

r?