### PR TITLE
[bug 1091716] Carry changes over to generic_feedback_dev.js

### DIFF
--- a/fjord/feedback/static/js/generic_feedback.js
+++ b/fjord/feedback/static/js/generic_feedback.js
@@ -63,7 +63,7 @@
         });
 
         $('#id_url').on('input', function() {
-            url = $.trim($(this).val());
+            var url = $.trim($(this).val());
             if (fjord.validateUrl(url) || !url.length) {
                 $(this).removeClass('invalid');
             } else {

--- a/fjord/feedback/static/js/generic_feedback_dev.js
+++ b/fjord/feedback/static/js/generic_feedback_dev.js
@@ -40,10 +40,10 @@
         function toggleSubmitButton() {
             var isValid = true;
 
-            if ($('#description').val().replace(/^\s+/, '') === ''
-                    || $('#description').hasClass('invalid')
-                    || $('#id_url').hasClass('invalid')
-                    || $('#id_email').hasClass('invalid')) {
+            if ($('#description').val().replace(/^\s+/, '') === '' ||
+                    $('#description').hasClass('invalid') ||
+                    $('#id_url').hasClass('invalid') ||
+                    $('#id_email').hasClass('invalid')) {
                 isValid = false;
             }
 
@@ -63,7 +63,8 @@
         });
 
         $('#id_url').on('input', function() {
-            if (fjord.validateUrl($(this).val())) {
+            var url = $.trim($(this).val());
+            if (fjord.validateUrl(url) || !url.length) {
                 $(this).removeClass('invalid');
             } else {
                 $(this).addClass('invalid');

--- a/smoketests/tests/generic/test_validation.py
+++ b/smoketests/tests/generic/test_validation.py
@@ -62,7 +62,10 @@ class TestValidation(TestCase):
         ]
         for url in valid:
             feedback_pg.set_url(url)
-            Assert.true(feedback_pg.is_url_valid)
+            Assert.true(
+                feedback_pg.is_url_valid,
+                msg=('failed url "%s"' % url)
+            )
 
         invalid = [
             'a',
@@ -70,7 +73,10 @@ class TestValidation(TestCase):
         ]
         for url in invalid:
             feedback_pg.set_url(url)
-            Assert.false(feedback_pg.is_url_valid)
+            Assert.false(
+                feedback_pg.is_url_valid,
+                msg=('failed url "%s"' % url)
+            )
 
     @pytest.mark.nondestructive
     def test_email_verification(self, mozwebqa):
@@ -89,7 +95,10 @@ class TestValidation(TestCase):
         ]
         for email in valid:
             feedback_pg.set_email(email)
-            Assert.true(feedback_pg.is_email_valid)
+            Assert.true(
+                feedback_pg.is_email_valid,
+                msg=('failed email "%s"' % email)
+            )
 
         invalid = [
             'foo@',
@@ -97,4 +106,7 @@ class TestValidation(TestCase):
         ]
         for email in invalid:
             feedback_pg.set_email(email)
-            Assert.false(feedback_pg.is_email_valid)
+            Assert.false(
+                feedback_pg.is_email_valid,
+                msg=('failed email "%s"' % email)
+            )


### PR DESCRIPTION
In bug #1091716, we updated
fjord/feedback/static/js/generic_feedback.js. However, because we're in
the middle of the remote-troubleshooting changes, we have a parallel
generic_feedback_dev.js file which has the remote-troubleshooting
changes and is currently "live".

This commit updates the generic_feedback_dev.js file with the changes we
made to generic_feedback.js.

r?