### PR TITLE
[bug 1119015] Fix API with ES 1.2.4

### DIFF
--- a/fjord/feedback/api_views.py
+++ b/fjord/feedback/api_views.py
@@ -88,7 +88,7 @@ class PublicFeedbackAPI(rest_framework.views.APIView):
         search = search.order_by('-created')
 
         # Explicitly include only publicly visible fields
-        search = search.values_dict(models.ResponseMappingType.public_fields())
+        search = search.values_dict(*models.ResponseMappingType.public_fields())
 
         maximum = smart_int(request.GET.get('max', None))
         maximum = maximum or 1000


### PR DESCRIPTION
We were passing in a tuple to values_dict() which would pass it to ES in
the fields key like this:

    'fields': [('id', 'description', ...)],

the problem being that we need to pass it as a list of fields not a list
of a tuple of fields. This fixes that.

r?