### PR TITLE
Fix the _persist_feedbackdev decorator

### DIFF
--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -333,6 +333,7 @@ PRODUCT_OVERRIDE = {
 
 def persist_feedbackdev(fun):
     """Persists a feedbackdev flag set via querystring in the cookies"""
+    @wraps(fun)
     def _persist_feedbackdev(request, *args, **kwargs):
         qs_feedbackdev = request.GET.get('feedbackdev', None)
         resp = fun(request, *args, **kwargs)


### PR DESCRIPTION
This fixes the decorator so that things that trace through it get the
right function name.

r?

This will make New Relic tracing more helpful.