### PR TITLE
[bug 1119972] Fix remote-troubleshooting checkbox

### DIFF
--- a/fjord/feedback/static/js/generic_feedback_dev.js
+++ b/fjord/feedback/static/js/generic_feedback_dev.js
@@ -139,6 +139,9 @@
                 $('#browser-ask').show();
                 remoteTroubleshooting.getData(function (data) {
                     browserData = data;
+                    if ($('#browser-ok').is(':checked')) {
+                        $('#browser-data').val(JSON.stringify(browserData));
+                    }
                 });
             }
         });

--- a/fjord/feedback/templates/feedback/generic_feedback.html
+++ b/fjord/feedback/templates/feedback/generic_feedback.html
@@ -149,27 +149,14 @@
               {# NOTE: "Firefox" only until we figure out how to deal with browser/product mismatches. #}
               <div id="browser-ask" class="private">
                 <div class="ask">
-                  <input id="browser-ok" name="browser_ok" type="checkbox">
+                  <input id="browser-ok" name="browser_ok" type="checkbox" checked>
                   <label class="browser-ok" for="browser-ok">
-                    <span class="happy">
-                      {% trans %}
-                        (Optional)
-                        Check here to provide technical information
-                        about your browser. This information helps us
-                        better understand our users and create better
-                        products.
-                        This data will be kept private.
-                      {% endtrans %}
-                    </span>
-                    <span class="sad">
-                      {% trans %}
-                        (Optional)
-                        Check here to provide technical information
-                        about your browser. This will help us diagnose
-                        problems more quickly.
-                        This data will be kept private.
-                      {% endtrans %}
-                    </span>
+                    {% trans %}
+                      Check here to provide technical information about your browser.
+                      This information helps us better understand our users and create better
+                      products. This information will be kept in accordance with our Privacy
+                      policy.
+                    {% endtrans %}
                   </label>
                   <input id="browser-data" name="browser_data" type="hidden" value="{}" />
                 </div>
@@ -193,7 +180,14 @@
               </div>
             </div>
             <div class="input-box">
-              <button id="form-submit-btn" class="complete btn submit" disabled>{{ _('Submit feedback') }}</button>
+              <button id="form-submit-btn" class="complete btn submit" disabled>
+                {% if LANG == 'en-US' %}
+                  {# NOTE: Changing this to Submit, but have to wait for translations to be done. #}
+                  {{ _('Submit') }}
+                {% else %}
+                  {{ _('Submit feedback') }}
+                {% endif %}
+              </button>
             </div>
           </section>
         </div>


### PR DESCRIPTION
This nixes the happy/sad text and replaces it with something better.

It also changes the checkbox to default to checked. In doing that, I had to do some wonky stuff to make sure the data was in the right place. We should redo that later when we can make bigger changes.

Also, I changed the text for the submit button. It's only for en-US since we don't have translations for that string.

r?