### PR TITLE
Document how to configure the timezone of the VM to match the host

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -419,6 +419,19 @@ We use memcached for caching. to flush the cache, do::
     echo "flush_all" | nc localhost 11211
 
 
+Issues with commit timestamps
+-----------------------------
+
+The Ubuntu image that we are using, has UTC as the configured timezone.
+Due to this, if you are in a different timezone and make commits from
+the VM, the commit timestamps will have a different timezone when
+compared to the timezone on the host computer. To have matching
+timezone on the host and the VM, run::
+
+    sudo dpkg-reconfigure tzdata
+
+and select your current timezone as the timezone for the VM.
+
 Where to go from here?
 ======================
 


### PR DESCRIPTION
This helps avoid odd timestamps in the commit history when the host computer is on a different timezone. Please feel free to suggest rewording of the text if appropriate.