### PR TITLE
 [heartbeat] add description for survey model and view

### DIFF
--- a/fjord/analytics/templates/analytics/analyzer/hb_surveys.html
+++ b/fjord/analytics/templates/analytics/analyzer/hb_surveys.html
@@ -37,6 +37,7 @@
       <table class="summarytable">
         <tr>
           <th>name</th>
+          <th>description</th>
           <th>enabled?</th>
           <th>created</th>
         </tr>
@@ -44,6 +45,7 @@
         {% for sur in surveys %}
           <tr>
             <td><pre>{{ sur.name }}</pre></td>
+            <td>{{ sur.description }}</td>
             <td>{{ sur.enabled }}</td>
             <td>{{ sur.created }}</td>
           </tr>

--- a/fjord/heartbeat/admin.py
+++ b/fjord/heartbeat/admin.py
@@ -4,7 +4,7 @@ from .models import Survey
 
 
 class SurveyAdmin(admin.ModelAdmin):
-    list_display = ('name', 'enabled', 'created')
+    list_display = ('name', 'enabled', 'created', 'description')
     list_filter = ('name', 'enabled', 'created')
 
 

--- a/fjord/heartbeat/models.py
+++ b/fjord/heartbeat/models.py
@@ -19,6 +19,7 @@ class Survey(ModelBase):
     name = models.CharField(max_length=100, unique=True)
     enabled = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
+    description = models.TextField(blank=True, default='')
 
     def __unicode__(self):
         return '%s: %s' % (

--- a/fjord/heartbeat/south_migrations/0009_auto__add_field_survey_description.py
+++ b/fjord/heartbeat/south_migrations/0009_auto__add_field_survey_description.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Survey.description'
+        db.add_column(u'heartbeat_survey', 'description',
+                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Survey.description'
+        db.delete_column(u'heartbeat_survey', 'description')
+
+
+    models = {
+        u'heartbeat.answer': {
+            'Meta': {'object_name': 'Answer'},
+            'addons': ('fjord.base.models.JSONObjectField', [], {'default': '{}', 'blank': 'True'}),
+            'build_id': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'blank': 'True'}),
+            'experiment_version': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'extra': ('fjord.base.models.JSONObjectField', [], {'default': '{}', 'blank': 'True'}),
+            'flow_began_ts': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'flow_engaged_ts': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'flow_id': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'flow_offered_ts': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'flow_voted_ts': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_test': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'locale': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'blank': 'True'}),
+            'max_score': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'partner_id': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'blank': 'True'}),
+            'person_id': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'platform': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'blank': 'True'}),
+            'profile_age': ('django.db.models.fields.BigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'profile_usage': ('fjord.base.models.JSONObjectField', [], {'default': '{}', 'blank': 'True'}),
+            'question_id': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'question_text': ('django.db.models.fields.TextField', [], {}),
+            'response_version': ('django.db.models.fields.IntegerField', [], {}),
+            'score': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'survey_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['heartbeat.Survey']", 'to_field': "'name'", 'db_column': "'survey_id'"}),
+            'updated_ts': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'variation_id': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'blank': 'True'})
+        },
+        u'heartbeat.survey': {
+            'Meta': {'object_name': 'Survey'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['heartbeat']


### PR DESCRIPTION
Add a description field to the model making it optional with a default
value of "". Update SurveyAdmin to list the description field. Update
the template used by survey view in the analyzer section to display the
description field