### PR TITLE
Tweak reverse to allow you to override the locale

### DIFF
--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -134,7 +134,7 @@ class TestFeedback(TestCase):
             count = models.Response.objects.count()
 
             # Hard-coded url so we're guaranteed to get /es/.
-            url = '/es/feedback/firefox'
+            url = reverse('feedback', args=(u'firefox',), locale='es')
             resp = self.client.post(url, {
                 'happy': 1,
                 'description': u'Firefox rocks for es!',


### PR DESCRIPTION
This makes it easier to use reverse in tests that involve non-en-US locales.
Before, we'd have to hard-code the url because reverse would do all this
stuff which would make it difficult to specify non-en-US locales. Now
we can do:

    url = reverse('some-thing', locale='es')

The changes were based on what Kitsune has.

r?