### PR TITLE
[bug 1054001] upgrade to django-browserid v0.11

### DIFF
--- a/fjord/base/browserid.py
+++ b/fjord/base/browserid.py
@@ -2,6 +2,7 @@ import urlparse
 
 from django.http import HttpResponseRedirect
 
+from django_browserid.http import JSONResponse
 from django_browserid.views import Verify
 
 from fjord.base.models import Profile
@@ -32,4 +33,7 @@ class FjordVerify(Verify):
             if redirect_to:
                 url = url + '?next=' + redirect_to
 
-            return HttpResponseRedirect(url)
+            return JSONResponse({
+                'email': self.user.email,
+                'redirect': url,
+            })

--- a/fjord/base/templates/base.html
+++ b/fjord/base/templates/base.html
@@ -61,7 +61,7 @@
               {% endif %}
               <li>{{ browserid_logout(text=_('Sign out')) }}</li>
             {% else %}
-              <li>{{ browserid_login(text=_('Sign in')) }}</li>
+              <li>{{ browserid_login(text=_('Sign in'), next=request.get_full_path()) }}</li>
             {% endif %}
           </ul>
         </header>

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -408,6 +408,7 @@ MINIFY_BUNDLES = {
     'js': {
         'base': (
             'js/lib/jquery.min.js',
+            'browserid/api.js',
             'browserid/browserid.js',
             'js/init.js',
             'js/ga.js',
@@ -422,6 +423,7 @@ MINIFY_BUNDLES = {
             'js/lib/jquery.flot.time.js',
             'js/lib/jquery.flot.resize.js',
             'js/dashboard.js',
+            'browserid/api.js',
             'browserid/browserid.js',
             'js/ga.js',
         ),
@@ -435,6 +437,7 @@ MINIFY_BUNDLES = {
             'js/lib/jquery.flot.time.js',
             'js/lib/jquery.flot.resize.js',
             'js/hourly_dashboard.js',
+            'browserid/api.js',
             'browserid/browserid.js',
             'js/ga.js',
         ),
@@ -448,6 +451,7 @@ MINIFY_BUNDLES = {
             'js/lib/jquery.flot.time.js',
             'js/lib/jquery.flot.resize.js',
             'js/product_dashboard.js',
+            'browserid/api.js',
             'browserid/browserid.js',
             'js/ga.js',
         ),
@@ -461,6 +465,7 @@ MINIFY_BUNDLES = {
             'js/lib/jquery.flot.time.js',
             'js/lib/jquery.flot.resize.js',
             'js/product_dashboard_firefox.js',
+            'browserid/api.js',
             'browserid/browserid.js',
             'js/ga.js',
         ),
@@ -556,7 +561,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.messages.context_processors.messages',
     'fjord.base.context_processors.i18n',
     'fjord.base.context_processors.globals',
-    'django_browserid.context_processors.browserid',
 )
 
 TEMPLATE_DIRS = (

--- a/fjord/urls.py
+++ b/fjord/urls.py
@@ -31,7 +31,7 @@ urlpatterns = patterns(
         )
     ),
 
-    (r'^browserid/', include('django_browserid.urls')),
+    (r'', include('django_browserid.urls')),
 
     (r'^grappelli/', include('grappelli.urls')),
     (r'^admin/', include(admin.site.urls)),

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -78,9 +78,8 @@ https://github.com/celery/billiard/archive/5652fe69e0a0623cea8f9f0c2810e001d4ad5
 # sha256: sSXkx6LhIZfZHt_5TesMpf_19yRaU11j8jH6P4mLWYw
 https://github.com/jsocol/bleach/archive/90a79d24fcce8f6404d9b636936e7886558495fb.tar.gz#egg=bleach
 
-# django-browserid: master~19
-# sha256: ENf2_W8JACouw1VJ96Nxl3ZX7Wox3ySOo4V0WocTXBc
-https://github.com/mozilla/django-browserid/archive/79ba1d01e742dfe95c08bb7517b9353e6c1d0050.tar.gz#egg=django-browserid
+# sha256: EXGi39Bz0MuXOkgtic_AweW52n1VHcCgAkEoZ-z1KT4
+django-browserid==0.11.1
 
 # django-cronjobs: tags/v0.2.3
 # sha256: lVao25u2Xj98ofZHQZPM_szNLaqxhWljy7ugRNt4_ug


### PR DESCRIPTION
* There are changes to how redirects are done. Instead of a 302, it's a field in the JSON response.
* I had to register the helpers manually because django_browserid is failing to do it. @Osmose says he has seen it before or something similar and is just as puzzled.
* There is a new js file to include.

To test manually, I logged in with an existing user and a new user. WFM.

That's it. r? (CC: @Osmose can you eyeball this to see if it makes sense?)