### PR TITLE
Handle Windows 10 user agents in sniffer

### DIFF
--- a/fjord/base/browsers.py
+++ b/fjord/base/browsers.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 # From http://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx
 WINDOWS_VERSION = {
+    'Windows NT 10.0': ('Windows', '10'),
     'Windows NT 6.4': ('Windows', '10'),
     'Windows NT 6.3': ('Windows', '8.1'),
     'Windows NT 6.2': ('Windows', '8'),


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/ie/hh869301%28v=vs.85%29.aspx

That suggests that Windows 10.0 using browsers will have a user agent
with "Windows NT 10.0" in it rather than "Windows NT 6.4". Figure we can
handle both for now.

Quick r?