### PR TITLE
[bug 1111641] Enable browser data capture for all locales

### DIFF
--- a/fjord/feedback/templates/feedback/generic_feedback.html
+++ b/fjord/feedback/templates/feedback/generic_feedback.html
@@ -144,8 +144,7 @@
               <input class="url" id="id_url" name="url" placeholder="http://" type="text">
             </div>
 
-            {% if waffle.flag('feedbackdev') and LANG == 'en-US' and product.display_name == 'Firefox' %}
-              {# NOTE: en-US only until we're sure it's good and translations are done. #}
+            {% if waffle.flag('feedbackdev') and product.display_name == 'Firefox' %}
               {# NOTE: "Firefox" only until we figure out how to deal with browser/product mismatches. #}
               <div id="browser-ask" class="private">
                 <div class="ask">

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -656,38 +656,12 @@ class TestFeedback(TestCase):
         eq_(r.status_code, 302)
         eq_(models.ResponsePI.objects.count(), 0)
 
-    @with_waffle('feedbackdev', True)
-    def test_browser_data_is_in_en_US(self):
-        """en-US folks should see this"""
-        url = reverse('feedback', args=(u'firefox',))
-        resp = self.client.get(url)
-        assert 'browser-data' in resp.content
-
     @with_waffle('feedbackdev', False)
     def test_browser_data_not_there_when_feedbackdev_is_false(self):
         """Doesn't show if feedbackdev flag is false"""
         url = reverse('feedback', args=(u'firefox',))
         resp = self.client.get(url)
         assert 'browser-data' not in resp.content
-
-    @with_waffle('feedbackdev', True)
-    @override_settings(DEV_LANGUAGES=('en-US', 'es'))
-    def test_browser_data_is_not_in_non_en_US(self):
-        """Only en-US folks should see this now"""
-        # FIXME: Remove this test when this is no longer true.
-        try:
-            # Hard-coded url so we're guaranteed to get /es/.
-            url = '/es/feedback/firefox'
-            resp = self.client.get(url)
-
-            assert 'browser-data' not in resp.content
-
-        finally:
-            # FIXME - We have to do another request to set the
-            # LocalizingClient back to en-US otherwise it breaks all
-            # tests ever. This is goofy-pants since it should get
-            # reset in test teardown.
-            self.client.get('/en-US/feedback/')
 
     def test_src_to_source(self):
         """We capture the src querystring arg in the source column"""


### PR DESCRIPTION
This removes the en-US requirement and the tests that made sure that
requirement was working.

r?