### PR TITLE
[bug 1124379] Upgrade peep and un-goofify it

### DIFF
--- a/bin/travis/install.sh
+++ b/bin/travis/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Install Python dependencies"
-python peep install \
+./peep.sh install \
     -r requirements/compiled.txt \
     -r requirements/requirements.txt \
     -r requirements/dev.txt

--- a/bin/vagrant_provision.sh
+++ b/bin/vagrant_provision.sh
@@ -54,17 +54,15 @@ VENV=/home/vagrant/.virtualenvs/fjordvagrant
 # Build virtual environment and activate it
 sudo -H -u vagrant virtualenv $VENV
 
-# Install Fjord requirements
-sudo -H -u vagrant $VENV/bin/python ./peep install -r requirements/requirements.txt
-
-# Install Fjord dev requirements
-sudo -H -u vagrant $VENV/bin/python ./peep install -r requirements/dev.txt
-
-# Install compiled requirements
-# Note: Need to do this before launching Elasticsearch because of
-# memory issues
+# Install bits we need for compiled requirements
 apt-get install -y -q libxml2 libxml2-dev libxslt1.1 libxslt1-dev
-sudo -H -u vagrant $VENV/bin/python ./peep install -r requirements/compiled.txt
+
+# Install Fjord requirements
+sudo -H -u vagrant -s -- <<EOF
+source $VENV/bin/activate
+cd ~/fjord
+./peep.sh install -r requirements/requirements.txt -r requirements/compiled.txt -r requirements/dev.txt
+EOF
 
 # Install Elasticsearch 0.90.10
 curl http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -432,6 +432,7 @@ timezone on the host and the VM, run::
 
 and select your current timezone as the timezone for the VM.
 
+
 Keeping up with changes to Fjord
 ================================
 
@@ -454,13 +455,14 @@ keep up with the new changes, here are some tips.
     UNSATISFIED: nosenicedots==0.5
 
   In such a scenario, you have to find out the requirements files in which
-  the unsatisfied requirements are listed and the use ``peep`` to install them.
+  the unsatisfied requirements are listed and the use ``peep.sh`` to install them.
   For example you might have to run::
 
-    ./peep install -r requirements/dev.txt
+    ./peep.sh install -r requirements/dev.txt
 
   if there are unsatisfied requirements in ``requirements/dev.txt``.
 
+  
 Where to go from here?
 ======================
 

--- a/peep.sh
+++ b/peep.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Get pip version number
+PIPVER=`pip --version | awk '{print $2}'`
+ARGS=""
+
+echo "peep.sh: Using pip $PIPVER"
+
+# If we're using pip 1.5, 1.6 or 6.0, then toss on the --no-use-wheel
+# argument.
+#
+# Note: If we encounter other versions of pip here that require other
+# things, we can toss them in.
+case $PIPVER in
+    1\.5*|1\.6*|6\.*)
+        echo "peep.sh: Wheel-using pip detected, so passing --no-use-wheel."
+        ARGS="--no-use-wheel"
+        ;;
+esac
+
+# Execute peep with the command line args plus the additional args
+# if any.
+python ./bin/peep-2.1.1.py "$@" $ARGS
+
+echo "peep.sh: Done!"


### PR DESCRIPTION
* upgrade peep to 2.1.1
* rework how we handle the wheels problem so that instead of applying
  tweaks to peep directly which is hard to maintain and error-prone,
  we do our tweaks in a shell script and tell everyone to use that
* update the documentation, vagrant provision script and travis stuff
  to use the new peep.sh

r?