### PR TITLE
[bug 1076879] Fix Response indexing retry

### DIFF
--- a/fjord/search/tasks.py
+++ b/fjord/search/tasks.py
@@ -84,10 +84,10 @@ def index_item_task(cls_path, item_id, **kwargs):
             raise
         retry_time = RETRY_TIMES[retries]
 
-        args = (mapping_type, item_id)
+        args = (cls_path, item_id)
         if not kwargs:
-            # Celery is lame. It requires that kwargs be non empty, but when
-            # EAGER is true, it provides empty kwargs.
+            # Celery requires that kwargs be non empty, but when EAGER
+            # is true, it provides empty kwargs. Yay.
             kwargs['_dummy'] = True
         index_item_task.retry(args, kwargs, exc, countdown=retry_time)
 


### PR DESCRIPTION
Occasionally, we'd get this error:

Task fjord.search.tasks.index_item_task with id
10b7fc0e-6f40-4338-9b4f-f449b0906676 raised exception:
'AttributeError("type object \'ResponseMappingType\' has no attribute
\'split\'",)'

What's going on is if indexing fails, then it builds a new task to retry
indexing. When it did that, it was incorrectly building the args
argument using the mapping type instance rather than the stringified
class path representation. This fixes that.

Plus I fixed one of the comments that wasn't appropriate.

r?