### PR TITLE
[bug 1111265] Fix browser data re: products and browsers

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -85,6 +85,13 @@ class Product(ModelBase):
         max_length=20,
     )
 
+    # If this product should grab browser data, which browsers should
+    # it grab browser data for. Note, this value should match what
+    # we're inferring from the user agent.
+    browser_data_browser = models.CharField(
+        max_length=100, blank=True, default=u'',
+        help_text=u'Grab browser data for browser product')
+
     objects = ProductManager()
 
     @classmethod
@@ -93,12 +100,16 @@ class Product(ModelBase):
 
     @classmethod
     def get_product_map(cls):
-        """Returns map of product slug -> db_name for enabled products"""
+        """Return map of product slug -> db_name for enabled products"""
         products = (cls.objects
                     .filter(enabled=True)
                     .values_list('slug', 'db_name'))
         return dict(prod for prod in products)
 
+    def collect_browser_data_for(self, browser):
+        """Return whether we should collect browser data from this browser"""
+        return browser and browser == self.browser_data_browser
+        
     def __unicode__(self):
         return self.display_name
 

--- a/fjord/feedback/south_migrations/0042_auto__add_field_product_browser_data_browser.py
+++ b/fjord/feedback/south_migrations/0042_auto__add_field_product_browser_data_browser.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Product.browser_data_browser'
+        db.add_column(u'feedback_product', 'browser_data_browser',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=100, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Product.browser_data_browser'
+        db.delete_column(u'feedback_product', 'browser_data_browser')
+
+
+    models = {
+        u'feedback.product': {
+            'Meta': {'object_name': 'Product'},
+            'browser_data_browser': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'blank': 'True'}),
+            'db_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_file': ('django.db.models.fields.CharField', [], {'default': "u'noimage.png'", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'on_dashboard': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_picker': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'translation_system': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'api': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'campaign': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'rating': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('fjord.base.models.EnhancedURLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        u'feedback.responsecontext': {
+            'Meta': {'object_name': 'ResponseContext'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': '{}'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responsepi': {
+            'Meta': {'object_name': 'ResponsePI'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': '{}'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']

--- a/fjord/feedback/templates/feedback/generic_feedback.html
+++ b/fjord/feedback/templates/feedback/generic_feedback.html
@@ -144,8 +144,7 @@
               <input class="url" id="id_url" name="url" placeholder="http://" type="text">
             </div>
 
-            {% if waffle.flag('feedbackdev') and product.display_name == 'Firefox' %}
-              {# NOTE: "Firefox" only until we figure out how to deal with browser/product mismatches. #}
+            {% if collect_browser_data %}
               <div id="browser-ask" class="private">
                 <div class="ask">
                   <input id="browser-ok" name="browser_ok" type="checkbox" checked>

--- a/fjord/feedback/tests/__init__.py
+++ b/fjord/feedback/tests/__init__.py
@@ -25,6 +25,7 @@ class ProductFactory(factory.DjangoModelFactory):
     enabled = True
     on_dashboard = True
     on_picker = True
+    browser_data_browser = u''
 
 
 class ResponseFactory(factory.DjangoModelFactory):

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -265,9 +265,19 @@ def generic_feedback(request, locale=None, product=None, version=None,
         return _handle_feedback_post(request, locale, product,
                                      version, channel)
 
+    # If the feedbackdev waffle flag is enabled and the product says
+    # we should collect browser data, then try to collect it.
+    # FIXME: Remove the feedbackdev flag (bug #1119813).
+    if (waffle.flag_is_active(request, 'feedbackdev') and
+            product.collect_browser_data_for(request.BROWSER.browser)):
+        collect_browser_data = True
+    else:
+        collect_browser_data = False
+
     return render(request, 'feedback/generic_feedback.html', {
         'form': form,
         'product': product,
+        'collect_browser_data': collect_browser_data,
         'TRUNCATE_LENGTH': TRUNCATE_LENGTH,
     })
 


### PR DESCRIPTION
Previously, we had the template code hardcoded to only collect browser
data if the product the user is leaving feedback for was "Firefox".
This prevents us from collecting browser data for "Firefox Dev Edition".

This changes the code so that the Product specifies whether to collect
browser data at all and which browser we'll collect browser data from.
For example, if the product has browser_data_browser=u'Android' and the
user is using Firefox for Android, then we'll add the browser data
collection bits to the template. Otherwise, we won't.

Also, I moved the "should we show the browser data section" bits from
the template to the view and added some better documentation.

r?