### PR TITLE
[bug 1093341] Fix gengo warning emails

### DIFF
--- a/bin/crontab/crontab.tpl
+++ b/bin/crontab/crontab.tpl
@@ -11,6 +11,9 @@ HOME=/tmp
 # to do an svn up.
 10 2 * * * root cd {{ source }} && (./bin/run_l10n_completion.sh {{ source }} {{ python }} > /dev/null)
 
+# Once a day at 3:00am run the translation daily activites.
+0 3 * * * {{ user }} cd {{ source }} && {{ python }} manage.py translation_daily -v 0 --traceback
+
 # Every hour, sync translations. This pulls and pushes to the various
 # translation systems.
 0 * * * * {{ user }} cd {{ source }} && {{ python }} manage.py translation_sync -v 0 --traceback

--- a/fjord/translations/management/commands/translation_daily.py
+++ b/fjord/translations/management/commands/translation_daily.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+
+from fjord.translations.models import get_translation_systems
+
+
+class Command(BaseCommand):
+    help = 'Runs translation-service daily activities.'
+
+    def handle(self, *args, **options):
+        verbose = (int(options.get('verbosity', 1)) >= 1)
+        system_classes = get_translation_systems().values()
+
+        for system_cls in system_classes:
+            if not system_cls.use_daily:
+                continue
+
+            system = system_cls()
+
+            if verbose:
+                print '>>> {0} translation system'.format(system.name)
+            system.run_daily_activities()
+
+        if verbose:
+            print '>>> Done!'


### PR DESCRIPTION
We want an email warning that the Gengo account balance is low to be
sent out once per day rather than every time the sync stuff runs. This
adds a "daily activities" kind of thing to translation modules so that
we can run:

    ./manage.py translation_daily

and have that run all the things that should happen only once a day.

Additionally, we add a cron job so that this runs in the morning.

r?