### PR TITLE
[bug 1129085] Infer version for Firefox Dev

### DIFF
--- a/fjord/analytics/analyzer_views.py
+++ b/fjord/analytics/analyzer_views.py
@@ -771,6 +771,7 @@ class ProductsUpdateView(FormView):
             instance.enabled = form.data.get('enabled') or False
             instance.on_dashboard = form.data.get('on_dashboard') or False
             instance.on_picker = form.data.get('on_picker') or False
+            instance.browser = form.data.get('browser') or u''
             instance.browser_data_browser = form.data.get('browser_data_browser') or u''
             self.object = instance.save()
         except Product.DoesNotExist:

--- a/fjord/analytics/forms.py
+++ b/fjord/analytics/forms.py
@@ -44,6 +44,7 @@ class ProductsUpdateForm(forms.ModelForm):
             'slug',
             'on_dashboard',
             'on_picker',
+            'browser',
             'browser_data_browser',
             'notes'
         ]

--- a/fjord/analytics/templates/analytics/analyzer/addproducts.html
+++ b/fjord/analytics/templates/analytics/analyzer/addproducts.html
@@ -13,6 +13,7 @@
         <th>slug</th>
         <th>automatic translations?</th>
         <th>feedback product url</th>
+        <th>browser</th>
         <th>browser data browser</th>
         <th>notes</th>
       </tr>
@@ -31,6 +32,7 @@
           <td>{{ prod.translation_system }}</td>
           {# FIXME - URL is hard-coded so it doesn't include the locale. Need better way to do this. #}
           <td><a href="https://input.mozilla.org/feedback/{{ prod.slug }}">https://input.mozilla.org/feedback/{{ prod.slug }}</a></td>
+          <td>{{ prod.browser }}</td>
           <td>{{ prod.browser_data_browser }}</td>
           <td>{{ prod.notes }}</td>
         </tr>

--- a/fjord/base/browsers.py
+++ b/fjord/base/browsers.py
@@ -41,7 +41,8 @@ def parse_ua(ua):
 
     :returns: Browser namedtuple with attributes:
 
-        - browser: "Unknown" or a browser like "Firefox", "Iceweasel", etc.
+        - browser: "Unknown" or a browser like "Firefox", "Iceweasel",
+          "Firefox for Android", etc.
         - browser_version: "Unknown" or a 3 dotted section like "14.0.1",
           "4.0.0", etc.
         - platform: "Unknown" or a platform like "Windows", "OS X",

--- a/fjord/feedback/admin.py
+++ b/fjord/feedback/admin.py
@@ -20,6 +20,7 @@ class ProductAdmin(admin.ModelAdmin):
         'db_name',
         'translation_system',
         'browser_data_browser',
+        'browser',
         'image_file',
         'notes',
         'slug')

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -92,6 +92,10 @@ class Product(ModelBase):
         max_length=100, blank=True, default=u'',
         help_text=u'Grab browser data for browser product')
 
+    browser = models.CharField(
+        max_length=30, blank=True, default=u'',
+        help_text=u'User agent inferred browser for this product if any')
+
     objects = ProductManager()
 
     @classmethod
@@ -369,6 +373,9 @@ class Response(ModelBase):
         elif browser.platform in (u'', u'Unknown'):
             return u''
 
+        # FIXME: We can do this because our user agent parser only
+        # knows about Mozilla browsers. If we ever change user agent
+        # parsers, we'll need to rethink this.
         return u'Firefox'
 
     @classmethod

--- a/fjord/feedback/south_migrations/0044_auto__add_field_product_browser.py
+++ b/fjord/feedback/south_migrations/0044_auto__add_field_product_browser.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Product.browser'
+        db.add_column(u'feedback_product', 'browser',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=30, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Product.browser'
+        db.delete_column(u'feedback_product', 'browser')
+
+
+    models = {
+        u'feedback.product': {
+            'Meta': {'object_name': 'Product'},
+            'browser': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'browser_data_browser': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'blank': 'True'}),
+            'db_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_file': ('django.db.models.fields.CharField', [], {'default': "u'noimage.png'", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'on_dashboard': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_picker': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'translation_system': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'api': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'campaign': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'rating': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('fjord.base.models.EnhancedURLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        u'feedback.responsecontext': {
+            'Meta': {'object_name': 'ResponseContext'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': '{}'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responsepi': {
+            'Meta': {'object_name': 'ResponsePI'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': '{}'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']

--- a/fjord/feedback/south_migrations/0045_populate_browser.py
+++ b/fjord/feedback/south_migrations/0045_populate_browser.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        data = [
+            ('Firefox', 'Firefox'),
+            ('Firefox for Android', 'Firefox for Android'),
+            ('Firefox OS', 'Firefox OS')
+        ]
+
+        for db_name, browser in data:
+            prod = orm.Product.objects.get(db_name=db_name)
+            prod.browser = browser
+            prod.save()
+
+    def backwards(self, orm):
+        orm.Product.objects.update(db_name=u'')
+
+    models = {
+        u'feedback.product': {
+            'Meta': {'object_name': 'Product'},
+            'browser': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'browser_data_browser': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'blank': 'True'}),
+            'db_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_file': ('django.db.models.fields.CharField', [], {'default': "u'noimage.png'", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'on_dashboard': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_picker': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'translation_system': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'feedback.response': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Response'},
+            'api': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'browser': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'browser_version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'campaign': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'channel': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'device': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'happy': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'rating': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'translated_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'url': ('fjord.base.models.EnhancedURLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
+        },
+        u'feedback.responsecontext': {
+            'Meta': {'object_name': 'ResponseContext'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': '{}'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responseemail': {
+            'Meta': {'object_name': 'ResponseEmail'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        },
+        u'feedback.responsepi': {
+            'Meta': {'object_name': 'ResponsePI'},
+            'data': ('fjord.base.models.JSONObjectField', [], {'default': '{}'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'opinion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['feedback.Response']"})
+        }
+    }
+
+    complete_apps = ['feedback']
+    symmetrical = True


### PR DESCRIPTION
Previously, we'd only infer the version if the browser from the user
agent matched the product db_name. That doesn't work for Firefox Dev
Edition or Firefox 64.

This fixes that so that we can explicitly state which "browser" a
product is. Then it'll match up, we can appropriately infer the
product version from the user-agent specified browser version, and we
can go home at night and feel like we did a good job at work.

r?