### PR TITLE
[bug 1053384] Make the filters visible even when there are no results

### DIFF
--- a/fjord/analytics/static/js/dashboard.js
+++ b/fjord/analytics/static/js/dashboard.js
@@ -56,7 +56,11 @@ $(function() {
             var $li = $(this);
             var value = $li.data('value');
             var bar_width = (value / max_value * 100).toString() + '%';
-            var percent = (value / total * 100).toFixed(0).toString() + '%';
+            var percent = "0%";
+            if (total !== 0) {
+                percent = (value / total * 100).toFixed(0).toString() + '%';
+            }
+
             var $label = $li.children('label');
 
             // Draw bars

--- a/fjord/analytics/views.py
+++ b/fjord/analytics/views.py
@@ -325,6 +325,22 @@ def dashboard(request):
         'product': {},
         'version': {}
     }
+
+    if request.GET.get('happy', None):
+        counts['happy'] = {True: 0}
+
+    if search_platform:
+        counts['platform'] = {search_platform: 0}
+
+    if search_locale:
+        counts['locale'] = {search_locale: 0}
+
+    if search_product:
+        counts['product'] = {search_product: 0}
+
+    if search_version:
+        counts['version'] = {search_version: 0}
+
     for param, terms in facets.facet_counts().items():
         for term in terms:
             name = term['term']


### PR DESCRIPTION
Set the count of selected filters to 0 before the actual count is calculated so that if the calculated count is zero, the filter is not excluded. Also fix the JavaScript code to handle 0 in the denominator when calculating the percentage.

Test for this fix has not been written since I have not used PyQuery before and have to figure out how test this.