### PR TITLE
[bug 1130469] Add a filter for hb test rows and distinguish them by color

### DIFF
--- a/fjord/analytics/analyzer_views.py
+++ b/fjord/analytics/analyzer_views.py
@@ -64,6 +64,18 @@ def hb_data(request, answerid=None):
         page = request.GET.get('page')
         answers = Answer.objects.order_by('-' + sortby)
         survey = request.GET.get('survey', survey)
+        showdata = request.GET.get('showdata', None)
+
+        if showdata:
+            if showdata == 'test':
+                answers = answers.filter(is_test=True)
+            elif showdata == 'notest':
+                answers = answers.exclude(is_test=True)
+            else:
+                showdata = 'all'
+        else:
+            showdata = 'all'
+
         if survey:
             try:
                 survey = Survey.objects.get(id=survey)
@@ -91,6 +103,7 @@ def hb_data(request, answerid=None):
         'pformat': pformat,
         'survey': survey,
         'surveys': Survey.objects.all(),
+        'showdata': showdata,
     })
 
 

--- a/fjord/analytics/static/css/dashboard.less
+++ b/fjord/analytics/static/css/dashboard.less
@@ -250,6 +250,9 @@ ul.bars {
     tr:nth-child(odd) {
       background-color: #eef;
     }
+    tr.test-answer {
+      background-color: #fdd;
+    }
   }
 }
 

--- a/fjord/analytics/templates/analytics/analyzer/hb_data.html
+++ b/fjord/analytics/templates/analytics/analyzer/hb_data.html
@@ -32,6 +32,11 @@
           <option value="{{ obj.id }}"{% if survey and survey.id == obj.id %} selected{% endif %} >{{ obj.name }}</option>
         {% endfor %}
       </select>
+      <select name="showdata">
+        <option value="all" {% if showdata == 'all' %} selected {% endif %}>ALL</option>
+        <option value="test" {% if showdata == 'test' %} selected {% endif %}>Only test data</option>
+        <option value="notest" {% if showdata == 'notest' %} selected {% endif %}>Only non-test data</option>
+      </select>
       <input type="hidden" name="sortby" value="{{ sortby }}">
       <input type="submit" value="Filter">
     </form>
@@ -169,7 +174,7 @@
           </tr>
 
           {% for ans in answers %}
-            <tr>
+            <tr {% if ans.is_test %} class="test-answer" {% endif %}>
               <td><a href="{{ url('hb_data', answerid=ans.id) }}">{{ ans.id }}</a></td>
               <td><span class="nowrap" title="{{ ans.updated_ts }}">{{ fix_ts(ans.updated_ts) }}</span></td>
               <td>{{ ans.experiment_version }}</td>


### PR DESCRIPTION
Add a filter for hiding test rows in hb survey answers table. Distinguish them by background color when not hidden.