### PR TITLE
[bug 1133734] Fix waffle cookie thing

### DIFF
--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -360,7 +360,9 @@ def persist_feedbackdev(fun):
         qs_feedbackdev = request.GET.get('feedbackdev', None)
         resp = fun(request, *args, **kwargs)
         if resp is not None and qs_feedbackdev is not None:
-            resp.set_cookie(waffle.COOKIE_NAME % 'feedbackdev', qs_feedbackdev)
+            resp.set_cookie(
+                waffle.settings.COOKIE_NAME % 'feedbackdev',
+                qs_feedbackdev)
 
         return resp
     return _persist_feedbackdev


### PR DESCRIPTION
The persist_feedbackdev decorator persists the querystring setting for
the feedbackdev flag into a cookie using a name that django-waffle will
key off of. That broke when we updated django-waffle since they moved
the value to a new module.

This fixes that to look at the correct module.

Quick r?