### PR TITLE
[bug 1130765] Add support for Fjord-Authorization header

### DIFF
--- a/docs/alerts_api.rst
+++ b/docs/alerts_api.rst
@@ -27,7 +27,7 @@ the token for.
 
 To use a token, include the following HTTP header in your HTTP POST::
 
-    Authorization: Token <TOKEN>
+    Fjord-Authorization: Token <TOKEN>
 
 where ``<TOKEN>`` is replaced by the token you received.
 
@@ -71,7 +71,7 @@ Using curl on the command line::
     curl -v -XPOST 'https://input.mozilla.org/api/v1/alerts/alert/` \
          -H 'Accept: application/json; indent=4' \
          -H 'Content-Type: application/json' \
-         -H 'Authorization: Token cd64de0e6c4c491f90fe1d362104c1e5' \
+         -H 'Fjord-Authorization: Token cd64de0e6c4c491f90fe1d362104c1e5' \
          -d '
     {
         "severity": 5,
@@ -256,12 +256,12 @@ Using curl on the command line::
     curl -v -XGET 'https://input.mozilla.org/api/v1/alerts/alert/?flavors=mfbt' \
          -H 'Accept: application/json; indent=4' \
          -H 'Content-Type: application/json' \
-         -H 'Authorization: Token cd64de0e6c4c491f90fe1d362104c1e5'
+         -H 'Fjord-Authorization: Token cd64de0e6c4c491f90fe1d362104c1e5'
 
     curl -v -XGET 'https://input.mozilla.org/api/v1/alerts/alert/?flavors=mfbt,cantina' \
          -H 'Accept: application/json; indent=4' \
          -H 'Content-Type: application/json' \
-         -H 'Authorization: Token cd64de0e6c4c491f90fe1d362104c1e5'
+         -H 'Fjord-Authorization: Token cd64de0e6c4c491f90fe1d362104c1e5'
 
 
 Using Python requests:

--- a/fjord/alerts/api_views.py
+++ b/fjord/alerts/api_views.py
@@ -21,7 +21,17 @@ class TokenAuthentication(authentication.BaseAuthentication):
 
     """
     def authenticate(self, request):
-        auth = request.META.get('HTTP_AUTHORIZATION', '').split()
+        auth = request.META.get('HTTP_AUTHORIZATION', '')
+        if not auth:
+            # FIXME: ZLB isn't passing along the Authorization header,
+            # so we never see it in Django land. This adds support for
+            # an additional header. Why support an additional one?
+            # Because when we switch to AWS, we can alleviate this
+            # silliness.
+            auth = request.META.get('HTTP_FJORD_AUTHORIZATION', '')
+
+        auth = auth.split()
+
         if not auth or auth[0].lower() != 'token':
             return None
 

--- a/fjord/alerts/tests/test_api.py
+++ b/fjord/alerts/tests/test_api.py
@@ -172,6 +172,27 @@ class AlertsGetAPIAuthTest(TestCase):
             {'detail': 'Flavor "fooflavor" is disabled.'}
         )
 
+    def test_fjord_authorization_token(self):
+        """Verify auth will use Fjord-Authorization header if Authorization
+        isn't there
+
+        """
+        token = TokenFactory()
+        flavor = AlertFlavorFactory(name='Foo', slug='fooflavor')
+        flavor.allowed_tokens.add(token)
+
+        qs = {
+            'flavors': flavor.slug
+        }
+        resp = self.client.get(
+            reverse('alerts-api') + '?' + urllib.urlencode(qs),
+            HTTP_FJORD_AUTHORIZATION='token ' + token.token
+        )
+
+        eq_(resp.status_code, 200)
+        eq_(json.loads(resp.content),
+            {u'count': 0, u'total': 0, u'alerts': []})
+
 
 class AlertsGetAPITest(TestCase):
     def test_get_one_flavor(self):


### PR DESCRIPTION
ZLB isn't passing along Authorization header. This adds support for
looking for a Fjord-Authorization header if Authorization isn't there.

Note: This is a stop-gap. As soon as we can ditch this, we should.

r?