### PR TITLE
[bug 1136840] Back out new WSGIHandler

### DIFF
--- a/wsgi/playdoh.wsgi
+++ b/wsgi/playdoh.wsgi
@@ -39,11 +39,11 @@ import manage
 
 # This is the original Django WSGIHandler preserved here in case
 # we ever have to back out the debuggable one.
-# from django.core.wsgi import get_wsgi_application
-# application = get_wsgi_application()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
 
-from fjord.wsgi import get_debuggable_wsgi_application
-application = get_debuggable_wsgi_application()
+# from fjord.wsgi import get_debuggable_wsgi_application
+# application = get_debuggable_wsgi_application()
 
 
 if newrelic:


### PR DESCRIPTION
This backs out the new WSGIHandler for stage/prod server environments.
When I landed this, I stopped getting the HB errors that I implemented
this to help track down. That's either a fluke or I messed something up.

Backing this out to eliminate the latter possibility.

Quick r?