### PR TITLE
[bug 1134475] Cleanup all references to input-dev environment

### DIFF
--- a/docs/maintain.rst
+++ b/docs/maintain.rst
@@ -185,7 +185,6 @@ should be an exceedingly rare occurrence.
 If ``.po`` files have errors, then those errors are noted in the
 postatus.txt files:
 
-* dev: https://input-dev.allizom.org/media/postatus.txt
 * stage: https://input.allizom.org/media/postatus.txt
 * prod: https://input.mozilla.org/media/postatus.txt
 

--- a/fjord/base/templates/contribute.json
+++ b/fjord/base/templates/contribute.json
@@ -22,8 +22,7 @@
     },
     "urls": {
         "prod": "https://input.mozilla.org/",
-        "stage": "https://input.allizom.org/",
-        "dev": "https://input-dev.allizom.org/"
+        "stage": "https://input.allizom.org/"
     },
     "keywords": [
         "python",


### PR DESCRIPTION
Remove all references to input-dev.allizom.org