### PR TITLE
[bug 1038512] Rewrite translation backfill admin page

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -121,6 +121,22 @@ class Product(ModelBase):
         return self.__unicode__().encode('ascii', 'ignore')
 
 
+class ResponseManager(models.Manager):
+    def need_translations(self, date_start=None, date_end=None):
+        """Returns responses that are translationless
+
+        Allows for optional timeframe so we can use this for
+        identifying instances that need to be backfilled.
+
+        """
+        objs = self.filter(translated_description='')
+        if date_start:
+            objs = objs.filter(created__gte=date_start)
+        if date_end:
+            objs = objs.filter(created__lte=date_end)
+        return objs
+
+
 @register_auto_translation
 @register_live_index
 class Response(ModelBase):
@@ -184,6 +200,8 @@ class Response(ModelBase):
                                 default=u'')
 
     created = models.DateTimeField(default=datetime.now)
+
+    objects = ResponseManager()
 
     class Meta:
         ordering = ['-created']

--- a/fjord/translations/admin.py
+++ b/fjord/translations/admin.py
@@ -8,7 +8,7 @@ from django.utils.module_loading import import_by_path
 
 from .gengo_utils import FjordGengo, GENGO_MACHINE_UNSUPPORTED
 from .models import GengoJob, GengoOrder
-from .tasks import create_translation_tasks
+from .tasks import translate_tasks_by_id_list
 from .utils import locale_equals_language
 from fjord.base.utils import smart_date, smart_str
 from fjord.feedback.models import Product
@@ -153,9 +153,9 @@ def translations_management_backfill_view(request):
     """Takes start and end dates and a model and backfills translations"""
     date_start = smart_date(request.POST.get('date_start'))
     date_end = smart_date(request.POST.get('date_end'))
-    model = smart_str(request.POST.get('model'))
+    model_path = smart_str(request.POST.get('model'))
 
-    if request.method == 'POST' and date_start and date_end and model:
+    if request.method == 'POST' and date_start and date_end and model_path:
         # NB: We just let the errors propagate because this is an
         # admin page. That way we get a traceback and all that detail.
 
@@ -165,23 +165,32 @@ def translations_management_backfill_view(request):
         # FIXME: We should do this in a less goofy way.
         date_end = date_end + timedelta(days=1)
 
-        model_cls = import_by_path(model)
+        model_cls = import_by_path(model_path)
 
-        # FIXME: This assumes the model has a "created" field. If it
-        # doesn't, then this breaks. When we have another model that we
-        # want to translate, we can figure out how to generalize this
-        # then.
-        objects = model_cls.objects.filter(
-            created__gte=date_start,
-            created__lte=date_end
+        # Get list of ids of all objects that need translating.
+        id_list = list(
+            model_cls.objects.need_translations(
+                date_start=date_start, date_end=date_end
+            )
+            .values_list('id', flat=True)
         )
 
-        total_jobs = 0
+        num = len(id_list)
 
-        for instance in objects:
-            total_jobs += len(create_translation_tasks(instance))
+        CHUNK_SIZE = 100
 
-        messages.success(request, '%s jobs added' % total_jobs)
+        # Need to generate a bunch of separate tasks because they take
+        # a long time to run, so we do CHUNK_SIZE per task.
+        while id_list:
+            chunk = id_list[:CHUNK_SIZE]
+            id_list = id_list[CHUNK_SIZE:]
+            translate_tasks_by_id_list.delay(model_path, chunk)
+
+        messages.success(
+            request,
+            u'Task created to backfill translations for %s instances' % num
+        )
+
         return HttpResponseRedirect(request.path)
 
     from fjord.translations.tasks import REGISTERED_MODELS

--- a/fjord/translations/models.py
+++ b/fjord/translations/models.py
@@ -19,7 +19,7 @@ from .gengo_utils import (
 )
 from .utils import locale_equals_language
 from fjord.base.models import ModelBase
-from fjord.base.utils import wrap_with_paragraphs
+from fjord.base.utils import instance_to_key, wrap_with_paragraphs
 from fjord.journal.models import Record
 from fjord.journal.utils import j_error, j_info
 
@@ -36,6 +36,13 @@ class SuperModel(models.Model):
     locale = models.CharField(max_length=5)
     desc = models.CharField(blank=True, default=u'', max_length=100)
     trans_desc = models.CharField(blank=True, default=u'', max_length=100)
+
+    def generate_translation_jobs(self, system=None):
+        """This always returns a fake translation job"""
+        return [
+            (instance_to_key(self), u'fake', self.locale, u'desc',
+             u'en', u'trans_desc')
+        ]
 
 
 _translation_systems = {}

--- a/fjord/translations/tasks.py
+++ b/fjord/translations/tasks.py
@@ -1,4 +1,5 @@
 from django.db.models.signals import post_save
+from django.utils.module_loading import import_by_path
 
 from celery import task
 
@@ -33,6 +34,16 @@ def translate_task(instance_key, system, src_lang, src_field,
     """
     instance = key_to_instance(instance_key)
     translate(instance, system, src_lang, src_field, dst_lang, dst_field)
+
+
+@task
+def translate_tasks_by_id_list(model_path, id_list):
+    """Takes a model path and a list of ids and generates translation tasks"""
+    model_cls = import_by_path(model_path)
+
+    objs = list(model_cls.objects.filter(id__in=id_list))
+    for obj in objs:
+        create_translation_tasks(obj)
 
 
 def create_translation_tasks(instance, system=None):

--- a/fjord/translations/tests/test_tasks.py
+++ b/fjord/translations/tests/test_tasks.py
@@ -1,0 +1,40 @@
+from nose.tools import eq_
+
+from ..models import SuperModel
+from ..tasks import translate_tasks_by_id_list
+from fjord.base.tests import TestCase
+
+
+class TranslateTasksByIdListTestCase(TestCase):
+    def test_one(self):
+        """Test the basic case"""
+        model_path = SuperModel.__module__ + '.' + SuperModel.__name__
+
+        obj = SuperModel(locale='br', desc=u'This is a test string')
+        obj.save()
+
+        # Verify no translation, yet
+        eq_(obj.trans_desc, u'')
+        translate_tasks_by_id_list.delay(model_path, [obj.id])
+
+        # Fetch the object from the db to verify it's been translated.
+        obj = SuperModel.objects.get(id=obj.id)
+        
+        eq_(obj.trans_desc, u'THIS IS A TEST STRING')
+
+    def test_many(self):
+        model_path = SuperModel.__module__ + '.' + SuperModel.__name__
+
+        objs = []
+        for i in range(50):
+            obj = SuperModel(locale='br', desc=u'string %d' % i)
+            obj.save()
+            objs.append(obj)
+        
+        translate_tasks_by_id_list.delay(model_path, [obj.id for obj in objs])
+
+        for obj in objs:
+            obj = SuperModel.objects.get(id=obj.id)
+            # Note: The fake translation just uppercases things. We're
+            # abusing inner knowledge of that here.
+            eq_(obj.trans_desc, obj.desc.upper())


### PR DESCRIPTION
The previous backfill page pulled all the instances for a given model
and date range (ouch) and then for each instance, told it to go create
translation tasks (double-ouch). That's a ton of work and far exceeds
the amount of time alotted for connections.

This version reimplements that and pushed the work to celery tasks.

r?