### PR TITLE
[bug 1144870] Add trans command

### DIFF
--- a/fjord/journal/models.py
+++ b/fjord/journal/models.py
@@ -25,7 +25,7 @@ class RecordManager(models.Manager):
             msg=msg,
             metadata=metadata
         )
-        if instance:
+        if instance and isinstance(instance, models.Model):
             rec.content_object = instance
         rec.save()
         return rec

--- a/fjord/translations/management/commands/trans.py
+++ b/fjord/translations/management/commands/trans.py
@@ -1,0 +1,48 @@
+from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+
+from fjord.translations.models import get_translation_systems
+
+
+class Command(BaseCommand):
+    help = 'Translate some text with specified system.'
+    option_list = BaseCommand.option_list + (
+        make_option('--system', type='string', dest='system',
+                    default=u'fake',
+                    help=u'The translation system to use.'),
+    )
+    def handle(self, *args, **options):
+        system = options['system']
+
+        if len(args) < 2:
+            raise CommandError(
+                'Usage: ./manage.py trans [--system=SYSTEM] lang text'
+            )
+
+        lang, text = args
+
+        system_classes = get_translation_systems().values()
+
+        class TextClass(object):
+            def __init__(self, src, locale):
+                self.id = 'ou812'
+                self.src = src
+                self.locale = locale
+                self.dest = ''
+
+            def save(self, *args, **kwargs):
+                pass
+
+        instance = TextClass(text, lang)
+
+        for system_cls in system_classes:
+            if system_cls.name == system:
+                system_cls().translate(instance, lang, 'src', 'en', 'dest')
+                print 'Translated to:'
+                print instance.dest
+                break
+
+        else:
+             print 'No such translation system.'
+             print ', '.join([system_cls.name for system_cls in system_classes])

--- a/fjord/translations/models.py
+++ b/fjord/translations/models.py
@@ -202,7 +202,6 @@ class DennisTranslator(TranslationSystem):
             translated = Translator([], pipeline).translate_string(text)
             setattr(instance, dst_field, translated)
             instance.save()
-            self.log_info(instance=instance, action='translate', msg='success')
 
 
 # ---------------------------------------------------------


### PR DESCRIPTION
This gives me a command-line way to test translation systems. It's a lot
easier than creating feedback and then triggering a translation for it
and then removing the translation from the db.

This just adds a command and tweaks some code to work better. It doesn't affect tests or production or anything else.

r?