### PR TITLE
[bug 1137022] Minor settings cleanup

### DIFF
--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -642,14 +642,6 @@ WAFFLE_OVERRIDE = True
 # Switch the test runner to django-nose
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
-# For absolute urls
-try:
-    DOMAIN = socket.gethostname()
-except socket.error:
-    DOMAIN = 'localhost'
-PROTOCOL = "http://"
-PORT = 80
-
 ## Logging
 LOG_LEVEL = logging.INFO
 HAS_SYSLOG = True

--- a/fjord/settings/local.py-dist
+++ b/fjord/settings/local.py-dist
@@ -41,16 +41,6 @@ DEV = True
 # See http://fjord.readthedocs.org/en/latest/l10n.html
 DEV_LANGUAGES = ('en-US',)
 
-# This sets some nose flags otherwise testing is very noisy. Comment
-# these out if you need the information they're quelling.
-#
-# See http://fjord.readthedocs.org/en/latest/testing.html
-NOSE_ARGS = [
-    '-s',                       # Don't ask any questions
-    '--nocapture',              # Don't capture stdout
-    '--logging-clear-handlers'  # Clear all other logging handlers
-]
-
 # Uncomment these to activate and customize Celery:
 # CELERY_ALWAYS_EAGER = False  # required to activate celeryd
 

--- a/fjord/settings/test.py
+++ b/fjord/settings/test.py
@@ -1,3 +1,13 @@
 DEBUG = TEMPLATE_DEBUG = True
 CELERY_ALWAYS_EAGER = True
 SESSION_COOKIE_SECURE = False
+
+# This sets some nose flags otherwise testing is very noisy. Comment
+# these out if you need the information they're quelling.
+#
+# See http://fjord.readthedocs.org/en/latest/testing.html
+NOSE_ARGS = [
+    '-s',                       # Don't ask any questions
+    '--nocapture',              # Don't capture stdout
+    '--logging-clear-handlers'  # Clear all other logging handlers
+]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-# Requirements from github urls because we're using non-reelased things
+# Requirements from github urls because we're using non-released things
 
 # django-mobility: no releases
 # sha256: vWKlBersFicnz_K9LUwnYlm1HhXt9bgxvWKB915vfog


### PR DESCRIPTION
* remove some more settings that aren't used anywhere (DOMAIN, PROTOCOL,
  PORT)
* move NOSE_ARGS settings from local.py-dist to test.py where they
  really should be
* (cosmetic) fix a typo in requirements.txt
* remove DEBUG = True from test.py since Django turns it False for
  tests anyhow

Quick r?