### PR TITLE
[bug 1141056] Fix history in onpopstate

### DIFF
--- a/fjord/feedback/static/js/generic_feedback.js
+++ b/fjord/feedback/static/js/generic_feedback.js
@@ -30,7 +30,7 @@
         window.onpopstate = function(ev) {
             // Switches the the appropriate card
             var pageId = ev.state ? ev.state.page : 'intro';
-            changeCard(pageId);
+            changeCard(pageId, true);
         };
 
         /**


### PR DESCRIPTION
When onpopstate kicks off, we were changing the page, but also tweaking
the history. We don't need to do that last bit since the event only
fires on history changing.

Quick r?