### PR TITLE
[bug 910789] Redo sampledata and add api responses

### DIFF
--- a/fjord/feedback/tests/__init__.py
+++ b/fjord/feedback/tests/__init__.py
@@ -51,6 +51,7 @@ class ResponseFactory(factory.DjangoModelFactory):
     version = factory.LazyAttribute(
         lambda a: browsers.parse_ua(a.user_agent).browser_version)
     locale = u'en-US'
+    api = None
 
 
 class ResponseEmailFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
This redoes how we generate sample data for feedback responses:

1. adds api responses based on the product
2. changes it to 100 happy + 100 sad + 1000 other responses
3. fixes it so we're looking at product tuples which group a product,
   version, platform and useragent together -- previously we did
   them separately which resulted in weirdo/impossible combinations
4. adjust the locale generator so it looks a bit more like typical
   Input data

This might also fix problems with the smoketests.

r?