### PR TITLE
[bug 1155905] Fix footer width in thanks page

### DIFF
--- a/fjord/feedback/static/css/generic_feedback.less
+++ b/fjord/feedback/static/css/generic_feedback.less
@@ -407,8 +407,9 @@ aside {
     color: #909090;
     font-size: 11px;
     height: 190px;
-    padding: 0 20px;
+    padding: 0;
     position: absolute;
+    width: 100%;
 
     &:hover {
       color: #606060;
@@ -425,7 +426,7 @@ aside {
 
     .contents {
       background: url(../img/footer-logo.png) no-repeat 0 0;
-      margin: 0 auto;
+      margin: 0 20px;
       padding: 0 0 0 60px;
       position: relative;
     }


### PR DESCRIPTION
On retina displays, the footer didn't extend all the way to the right
side of the "page". This fixes that.

Quick r?