### PR TITLE
[bug 1144159] Rework celeryd code and fix mysql error

### DIFF
--- a/fjord/celery.py
+++ b/fjord/celery.py
@@ -1,15 +1,10 @@
 from __future__ import absolute_import
 
-import os
-
 from celery import Celery
 
 from django.conf import settings
 
 
 app = Celery('fjord')
-
-# Using a string here means the worker will not have to
-# pickle the object when using Windows.
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/fjord/manage_utils.py
+++ b/fjord/manage_utils.py
@@ -6,7 +6,6 @@ These functions shouldn't be used after startup is completed.
 """
 import logging
 import os
-import site
 import sys
 from itertools import chain
 
@@ -186,7 +185,7 @@ def monkeypatch():
     from jingo import load_helpers
     load_helpers()
 
-    logging.debug("Note: monkeypatches executed in %s" % __file__)
+    logging.debug('Note: monkeypatches executed in %s' % __file__)
 
     # Prevent it from being run again later.
     _has_patched = True

--- a/manage.py
+++ b/manage.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import os
+# Do this before *anything*.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fjord.settings')
 
 from fjord import manage_utils
 
 
-if __name__ == "__main__":
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fjord.settings')
-
+if __name__ == '__main__':
     # This has to get called after DJANGO_SETTINGS_MODULE stuff has
     # been sorted out.
     manage_utils.setup_environ()


### PR DESCRIPTION
We were getting a sporadic "MySQL has gone away" error in production
which we tracked down to not having DJANGO_SETTINGS_MODULE set when the
celery django fixup code executed which meant we were getting the
default celery loader which didn't clean up db connection before working
on celery tasks. Whew.

This fixes that by moving the os.environ.setdefault() line to the top of
manage.py along with a comment.

This also redoes the celeryd.py code so that it's a copy/paste of
the original source from django-celery so it's easier to maintain going
forward if they change their code.

r?