### PR TITLE
[bug 1161746] More alerts api code cleanup

### DIFF
--- a/docs/alerts_api.rst
+++ b/docs/alerts_api.rst
@@ -225,6 +225,7 @@ Possibilities include:
 
 * missing name/url in links
 * flavor is disabled
+* flavor is missing
 
 
 HTTP 401: Unauthorized
@@ -241,12 +242,6 @@ HTTP 403: Forbidden
 
 Your token doesn't have permission to GET/POST to the specified alert
 flavor.
-
-
-HTTP 404: Not found
-~~~~~~~~~~~~~~~~~~~
-
-The flavor you're GET/POSTing doesn't exist.
 
 
 HTTP 500: Server error

--- a/fjord/alerts/tests/test_api.py
+++ b/fjord/alerts/tests/test_api.py
@@ -22,9 +22,9 @@ class AlertsGetAPIAuthTest(TestCase):
             reverse('alerts-api') + '?' + urllib.urlencode(qs)
         )
 
-        eq_(resp.status_code, 404)
+        eq_(resp.status_code, 400)
         eq_(json.loads(resp.content),
-            {'detail': {'flavor': ['Flavor "fooflavor" does not exist.']}}
+            {'detail': {'flavors': ['Flavor "fooflavor" does not exist.']}}
         )
 
         qs = {
@@ -34,9 +34,12 @@ class AlertsGetAPIAuthTest(TestCase):
             reverse('alerts-api') + '?' + urllib.urlencode(qs)
         )
 
-        eq_(resp.status_code, 404)
+        eq_(resp.status_code, 400)
         eq_(json.loads(resp.content),
-            {'detail': {'flavor': ['Flavor "fooflavor" does not exist.']}}
+            {'detail': {'flavors': [
+                'Flavor "fooflavor" does not exist.',
+                'Flavor "barflavor" does not exist.'
+            ]}}
         )
 
         flavor = AlertFlavorFactory(name='Foo', slug='fooflavor')
@@ -48,9 +51,9 @@ class AlertsGetAPIAuthTest(TestCase):
             reverse('alerts-api') + '?' + urllib.urlencode(qs)
         )
 
-        eq_(resp.status_code, 404)
+        eq_(resp.status_code, 400)
         eq_(json.loads(resp.content),
-            {'detail': {'flavor': ['Flavor "barflavor" does not exist.']}}
+            {'detail': {'flavors': ['Flavor "barflavor" does not exist.']}}
         )
 
     def test_missing_auth_token(self):
@@ -171,7 +174,7 @@ class AlertsGetAPIAuthTest(TestCase):
 
         eq_(resp.status_code, 400)
         eq_(json.loads(resp.content),
-            {'detail': {'flavor': ['Flavor "fooflavor" is disabled.']}}
+            {'detail': {'flavors': ['Flavor "fooflavor" is disabled.']}}
         )
 
     def test_fjord_authorization_token(self):

--- a/fjord/base/api_utils.py
+++ b/fjord/base/api_utils.py
@@ -3,6 +3,8 @@ from django.conf import settings
 import pytz
 from rest_framework import fields
 from rest_framework import serializers
+from rest_framework import status
+from rest_framework.exceptions import APIException
 
 
 class UTCDateTimeField(fields.DateTimeField):
@@ -80,3 +82,8 @@ class StrictArgumentsMixin(object):
                     )
 
         return data
+
+
+class NotFound(APIException):
+    status_code = status.HTTP_404_NOT_FOUND
+    default_detail = 'Not found.'


### PR DESCRIPTION
This cleans up the alerts api code a bit more:

* use DRF exceptions where appropriate
* move "aflavors" validation to serializer and make the error handling
  better so that it spits out all errors at once rather than just the
  first one it hit
* fix a typo in HTTP 400 for flavors
* add a NotFound exception--this exists in DRF3, so when we upgrade we
  can use theirs

r?