### PR TITLE
[bug 1165996] Explicitly validate description in api

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from django.core.cache import cache
-from django.core.exceptions import ValidationError
 from django.db import models
 
 from elasticutils.contrib.django import Indexable, MLT
@@ -670,6 +669,13 @@ class PostResponseSerializer(serializers.Serializer):
         max_length=100, allow_null=False, default=u'')
     campaign = serializers.CharField(
         max_length=100, allow_null=False, default=u'')
+
+    def validate_description(self, value):
+        if not value.strip():
+            raise serializers.ValidationError(
+                u'This field may not be blank.'
+            )
+        return value
 
     def validate_url(self, value):
         if value:

--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -442,6 +442,19 @@ class PostFeedbackAPITest(TestCase):
         feedback = models.Response.objects.latest(field_name='id')
         eq_(feedback.happy, False)
 
+    def test_whitespace_description_is_invalid(self):
+        data = {
+            'happy': True,
+            'description': u' ',
+            'product': u'Firefox OS'
+        }
+
+        r = self.client.post(
+            reverse('feedback-api'),
+            content_type='application/json',
+            data=json.dumps(data))
+        eq_(r.status_code, 400)
+
     def test_invalid_unicode_url(self):
         """Tests an API call with invalid unicode URL"""
         data = {


### PR DESCRIPTION
What was happening was that if the description was whitespace, it would
get validated (it's not blank, so yippie!), and then get stripped and
saved. That resulted in blank descriptions.

This adds validation to make sure we don't get descriptions that are
whitespace.

r?