### PR TITLE
[bug 1077596] Temporary histogram feedback API

### DIFF
--- a/fjord/feedback/urls.py
+++ b/fjord/feedback/urls.py
@@ -22,7 +22,11 @@ urlpatterns = patterns(
     url(r'^happy/?$', 'happy_redirect', name='happy-redirect'),
     url(r'^sad/?$', 'sad_redirect', name='sad-redirect'),
 
-    # API for posting feedback
+    url(r'^api/v1/feedback/histogram/?$',
+        api_views.FeedbackHistogramAPI.as_view(),
+        name='feedback-histogram-api'),
+
+    # API for getting/posting feedback
     # Note: If we change the version number here, we also have to change it
     # in the ResponseSerializer.
     url(r'^api/v1/feedback/?$',


### PR DESCRIPTION
This is a temporary histogram feedback API. "Temporary" in this
case means we'll deprecate it as soon as we write a better one
using Elasticsearch aggregations. As soon as we do that, we'll
deprecate this one.

There's a bunch of FIXMEs in the code. We can fix them if this proves
less temporary than I'd like.

r?