### PR TITLE
[bug 1169261] Implement ga_track_event

### DIFF
--- a/fjord/base/google_utils.py
+++ b/fjord/base/google_utils.py
@@ -1,0 +1,50 @@
+import sys
+
+import requests
+
+from django.conf import settings
+
+from fjord.celery import app
+
+
+GOOGLE_API_URL = 'https://ssl.google-analytics.com/collect'
+
+
+@app.task
+def post_event(params):
+    requests.post(GOOGLE_API_URL, data=params)
+
+
+def ga_track_event(params, async=True):
+    """Sends event tracking information to Google.
+
+    :arg params: Params specific to the event being tracked. Particularly
+        keys ``cid``, ``ec``, ``ea``, ``el`` and ``ev``.
+    :arg async: Whether to do it now or later via celery.
+
+    >>> ga_track_event({'cid': 'xxxx', 'ec': 'sumo_suggest', 'ea': 'suggest'})
+
+    .. Note::
+
+       If this runs in DEBUG mode or as part of a test suite, it'll
+       prepend ``test_`` to the ``ec`` parameter. This reduces
+       testing/development data hosing your production data.
+
+    """
+    params.update({
+        'v': '1',
+        # FIXME: turn this into a setting. the complexity is that it's
+        # also in fjord/base/static/js/ga.js.
+        'tid': 'UA-35433268-26',
+        't': 'event'
+    })
+
+    # If we're in DEBUG mode or running tests, we don't want to hose
+    # production data, so we prepend test_ to the category.
+    if 'ec' in params and settings.DEBUG or 'test' in sys.argv:
+        params['ec'] = 'test_' + params['ec']
+
+    if async:
+        post_event.delay(params)
+    else:
+        post_event(params)

--- a/fjord/base/tests/test_google_utils.py
+++ b/fjord/base/tests/test_google_utils.py
@@ -1,0 +1,101 @@
+import sys
+from functools import wraps
+
+import requests_mock
+from mock import MagicMock, patch
+from nose.tools import eq_
+
+from fjord.base.google_utils import GOOGLE_API_URL, ga_track_event
+from fjord.base.tests import TestCase
+
+
+def set_sys_argv(sys_argv):
+    """Decorator for setting sys.argv
+
+    ::
+
+        class SomeTestCase(TestCase):
+            @set_sys_argv(['test'])
+            def test_something(self):
+                ...
+
+    """
+    def _set_sys_argv(fun):
+        @wraps(fun)
+        def handler(*args, **kwargs):
+            _old_sys_argv = sys.argv
+            sys.argv = sys_argv
+            try:
+                return fun(*args, **kwargs)
+            finally:
+                sys.argv = _old_sys_argv
+        return handler
+    return _set_sys_argv
+
+
+class GoogleUtilsTestCase(TestCase):
+    @set_sys_argv(['test'])
+    def test_ga_track_event_test(self):
+        with patch('fjord.base.google_utils.requests') as req_patch:
+            # Create a mock that we can call .post() on and query what
+            # it got params-wise. It doesn't matter what the return
+            # is.
+            req_patch.post = MagicMock()
+            params = {'cid': 'xxx', 'ec': 'ou812'}
+
+            ga_track_event(params)
+
+            req_patch.post.assert_called_once_with(
+                GOOGLE_API_URL,
+                data={
+                    'tid': 'UA-35433268-26',
+                    'v': '1',
+                    't': 'event',
+                    'ec': 'test_ou812',  # "test_" is prepended.
+                    'cid': 'xxx'
+                }
+            )
+
+    @set_sys_argv([])
+    def test_ga_track_event_non_test(self):
+        with patch('fjord.base.google_utils.requests') as req_patch:
+            # Create a mock that we can call .post() on and query what
+            # it got params-wise. It doesn't matter what the return
+            # is.
+            req_patch.post = MagicMock()
+            params = {'cid': 'xxx', 'ec': 'ou812'}
+
+            ga_track_event(params)
+
+            req_patch.post.assert_called_once_with(
+                GOOGLE_API_URL,
+                data={
+                    'tid': 'UA-35433268-26',
+                    'v': '1',
+                    't': 'event',
+                    'ec': 'ou812',  # "test_" is not prepended.
+                    'cid': 'xxx'
+                }
+            )
+
+    def test_ga_track_event_async_true(self):
+        """async=True, then delay() gets called once"""
+        with requests_mock.Mocker() as m:
+            m.post(GOOGLE_API_URL, text='')
+
+            d = 'fjord.base.google_utils.post_event.delay'
+            with patch(d) as delay_patch:
+                params = {'cid': 'xxx', 'ec': 'ou812'}
+                ga_track_event(params, async=True)
+                eq_(delay_patch.call_count, 1)
+
+    def test_ga_track_event_async_false(self):
+        """async=False, then delay() never gets called"""
+        with requests_mock.Mocker() as m:
+            m.post(GOOGLE_API_URL, text='')
+
+            d = 'fjord.base.google_utils.post_event.delay'
+            with patch(d) as delay_patch:
+                params = {'cid': 'xxx', 'ec': 'ou812'}
+                ga_track_event(params, async=False)
+                eq_(delay_patch.call_count, 0)


### PR DESCRIPTION
This adds a ga_track_event function that lets us capture data and post
it from the server. This is just like what we do currently with statsd,
but it's intended specifically for events and pushes the data to Google
where we can look at event flows.

r?