### PR TITLE
[bug 1129615] Change "get help" link to point to AAQ

### DIFF
--- a/fjord/feedback/templates/feedback/thanks.html
+++ b/fjord/feedback/templates/feedback/thanks.html
@@ -41,7 +41,7 @@
           <div class="part" id="thanks_help">
             <h2>{{ _('Having problems? Get help.') }}</h2>
             <p>
-              {% trans url="https://support.mozilla.org/?utm_source=input&utm_campaign=thankyou" %}
+              {% trans url="https://support.mozilla.org/questions/new?utm_source=input&utm_campaign=thankyou" %}
                 Go to our support forum where you can <a href="{{ url }}">get help and
                 find answers</a>.
               {% endtrans %}


### PR DESCRIPTION
This changes the "get help" link on the thank you page to point directly
to asking a new question rather than to the front page of SUMO per
Verdi's suggestion.

Quick r?