### PR TITLE
[bug 1167192] In python, stop using the gettext from tower.

### DIFF
--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -101,7 +101,7 @@ templates.
 
 In Python::
 
-    from tower import ugettext as _, ugettext_lazy as _lazy
+    from django.utils.translation import ugettext as _, ugettext_lazy as _lazy
 
     yodawg = _lazy('The Internet')
 

--- a/fjord/analytics/helpers.py
+++ b/fjord/analytics/helpers.py
@@ -1,5 +1,6 @@
+from django.utils.translation import ugettext_lazy as _lazy
+
 from jingo import register
-from tower import ugettext_lazy as _lazy
 
 
 @register.filter

--- a/fjord/analytics/views.py
+++ b/fjord/analytics/views.py
@@ -11,12 +11,12 @@ from django.http import (
     HttpResponseRedirect
 )
 from django.shortcuts import get_object_or_404, render
+from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from elasticsearch import ElasticsearchException
 from elasticutils.contrib.django import F, es_required_or_50x
 from mobility.decorators import mobile_template
-from tower import ugettext as _
 
 from fjord.analytics.utils import (
     counts_to_options,

--- a/fjord/base/helpers.py
+++ b/fjord/base/helpers.py
@@ -9,10 +9,10 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.template import defaultfilters
 from django.utils.encoding import smart_str
 from django.utils.html import strip_tags
+from django.utils.translation import ugettext_lazy as _lazy
 
 import jinja2
 from jingo import register
-from tower import ugettext_lazy as _lazy
 from product_details import product_details
 
 from fjord.base.urlresolvers import reverse

--- a/fjord/base/models.py
+++ b/fjord/base/models.py
@@ -2,8 +2,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.db import models
-
-from tower import ugettext_lazy as _lazy
+from django.utils.translation import ugettext_lazy as _lazy
 
 from fjord.base import forms
 from fjord.base.validators import EnhancedURLValidator

--- a/fjord/feedback/config.py
+++ b/fjord/feedback/config.py
@@ -1,4 +1,4 @@
-from tower import ugettext_lazy as _lazy
+from django.utils.translation import ugettext_lazy as _lazy
 
 
 # List of (value, name, _lazy(name)) tuples for countries Firefox OS has

--- a/fjord/feedback/helpers.py
+++ b/fjord/feedback/helpers.py
@@ -1,5 +1,6 @@
+from django.utils.translation import ugettext_lazy as _lazy
+
 from jingo import register
-from tower import ugettext_lazy as _lazy
 
 from fjord.feedback.config import CODE_TO_COUNTRY
 

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -2,12 +2,12 @@ from datetime import datetime, timedelta
 
 from django.core.cache import cache
 from django.db import models
+from django.utils.translation import ugettext_lazy as _lazy
 
 from elasticutils.contrib.django import Indexable, MLT
 from product_details import product_details
 from rest_framework import serializers
 from statsd import statsd
-from tower import ugettext_lazy as _lazy
 
 from fjord.base.browsers import parse_ua
 from fjord.base.domain import get_domain

--- a/fjord/suggest/providers/sumosuggest.py
+++ b/fjord/suggest/providers/sumosuggest.py
@@ -1,8 +1,9 @@
 import json
 import logging
 
+from django.utils.translation import ugettext as _
+
 import requests
-from tower import ugettext as _
 
 from fjord.base.google_utils import ga_track_event
 from fjord.suggest import Link, Suggester


### PR DESCRIPTION
As mentioned in IRC, I created fjord/base/translation.py to create the lazy versions. I am open to other ideas.

r?