### PR TITLE
[bug 1172019] Make thank you page product-agnostic

### DIFF
--- a/fjord/feedback/templates/feedback/thanks_l10nized.html
+++ b/fjord/feedback/templates/feedback/thanks_l10nized.html
@@ -1,0 +1,98 @@
+{% extends "feedback/base.html" %}
+
+{% block page_title %}{{ _('Thanks') }}{% endblock %}
+
+{% block site_js %}
+  {{ js('singlecard') }}
+{% endblock %}
+
+{% set extra_body_attrs = {'data-ga-push': '[["_trackEvent", "FeedbackFlow", "generic-thanks"]]'} %}
+
+{% block content %}
+  <div class="content" id="thanks">
+    <header>
+      <div class="header-content">
+        <div class="middle">
+          <h1>{{ _('Thanks for Your Feedback') }}</h1>
+        </div>
+      </div>
+    </header>
+
+    <div class="deck">
+      <div class="card thanks">
+        <section>
+          <div class="part">
+            {% trans product=product %}
+              Your feedback will be used to create a better experience in
+              future releases of {{ product }}.
+            {% endtrans %}
+          </div>
+
+          {% if suggestions %}
+            <div class="part" id="suggestions">
+              <h2>{{ _('Suggestions from your feedback:') }}</h2>
+              <div id="suggestions-list">
+                {% for link in suggestions %}
+                  <div class="suggestion {{ link.cssclass }}">
+                    {#
+                    Note: This means the suggestion provider is in charge of
+                    providing localized text for the summary and description.
+                    #}
+                    <a href="{{ link.url }}">{{ link.summary }}</a>
+                    {{ link.description }}
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          {% else %}
+            <div class="part">
+              <h2>{{ _('Having problems? Get help.') }}</h2>
+              <p>
+                {% trans url="https://support.mozilla.org/questions/new?utm_source=input&utm_campaign=thankyou" %}
+                  Go to our support forum where you can <a href="{{ url }}">get help and
+                  find answers</a>.
+                {% endtrans %}
+              </p>
+            </div>
+          {% endif %}
+
+          {#
+          Note: This is specifically about downloading Firefox. It probably
+          only makes sense for desktop browsers, though.
+          #}
+          <div class="part">
+            <h2>{{ _('Shape the future of Firefox.') }}</h2>
+            <p>
+              {% trans download_url="http://www.mozilla.org/firefox/channel" %}
+                Download
+                <a href="{{ download_url }}">the Firefox build that is right for you</a>.
+              {% endtrans %}
+            </p>
+          </div>
+
+          <div class="part">
+            <h2>{{ _('Contribute to Mozilla.') }}</h2>
+            <p>
+              {% trans url='http://mozilla.org/contribute/', product=product %}
+                Learn how you can <a href="{{ url }}">make {{ product }} and Mozilla better</a>.
+              {% endtrans %}
+            </p>
+          </div>
+
+          <div class="part" id="thanks-news">
+            <h2>
+              {% trans product=product %}
+                Find the latest news about {{ product }}.
+              {% endtrans %}
+            </h2>
+            <ul>
+              <li><a id="twitter" href="http://twitter.com/firefox"><span>Twitter</span></a></li>
+              <li><a id="facebook" href="http://www.facebook.com/Firefox"><span>Facebook</a></span></li>
+              <li><a id="planet" href="http://planet.mozilla.org/"><span>Planet Mozilla</a></span></li>
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This creates a copy of the thank you page which has strings that are
product agnostic. As soon as the strings are translated, we'll ditch the
old version for this version.

r?