### PR TITLE
[bug 1173763] Tweak error logging code

### DIFF
--- a/fjord/suggest/providers/sumosuggest.py
+++ b/fjord/suggest/providers/sumosuggest.py
@@ -126,7 +126,7 @@ class SUMOSuggestRedirector(Redirector):
         # FIXME: Putting this in here because I can't figure out
         # what's going on with bug #1173763 and hoping this sheds some
         # light.
-        if url == 'https:':
+        if not url.startswith('https://') or ' ' in url:
             j_error(
                 app='suggest',
                 src='sumosuggest',


### PR DESCRIPTION
Still can't figure out why we're posting "https://" to GA. Trying this
out to see if it sheds light on the situation.

Quick r?