### PR TITLE
[bug 1167192] Changed text domain for L10n from messages to django.

### DIFF
--- a/bin/l10n_completion.py
+++ b/bin/l10n_completion.py
@@ -34,7 +34,7 @@ USAGE = 'usage: %prog [OPTIONS] OUTPUT-FILE LOCALES-DIR'
 
 def get_language(fn):
     """Given a filename, returns the locale it applies to"""
-    # FIXME - this expects the fn to be '.../XX/LC_MESSAGES/messages.po'
+    # FIXME - this expects the fn to be '.../XX/LC_MESSAGES/django.po'
     return fn.split(os.sep)[-3]
 
 

--- a/bin/stats-po.sh
+++ b/bin/stats-po.sh
@@ -5,7 +5,7 @@
 
 echo "Printing number of untranslated strings found in locales:"
 
-for lang in `find $1 -type f -name "messages.po" | sort`; do
+for lang in `find $1 -type f -name "django.po" | sort`; do
 dir=`dirname $lang`
     stem=`basename $lang .po`
     count=$(msgattrib --untranslated $lang | grep -c "msgid")

--- a/bin/test_locales.sh
+++ b/bin/test_locales.sh
@@ -22,9 +22,9 @@ echo "extract and merge...."
 echo "creating dir...."
 mkdir -p locale/xx/LC_MESSAGES
 
-echo "copying messages.pot file...."
-cp locale/templates/LC_MESSAGES/messages.pot locale/xx/LC_MESSAGES/messages.po
+echo "copying django.pot file...."
+cp locale/templates/LC_MESSAGES/django.pot locale/xx/LC_MESSAGES/django.po
 
-echo "translate messages.po file...."
-./manage.py translate --pipeline=html,pirate locale/xx/LC_MESSAGES/messages.po
+echo "translate django.po file...."
+./manage.py translate --pipeline=html,pirate locale/xx/LC_MESSAGES/django.po
 locale/compile-mo.sh locale/xx/

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -63,7 +63,7 @@ USE_I18N = True
 USE_L10N = True
 
 # Gettext text domain
-TEXT_DOMAIN = 'messages'
+TEXT_DOMAIN = 'django'
 STANDALONE_DOMAINS = [TEXT_DOMAIN]
 TOWER_KEYWORDS = {'_lazy': None}
 TOWER_ADD_HEADERS = True
@@ -561,7 +561,7 @@ CSRF_FAILURE_VIEW = 'fjord.base.views.csrf_failure'
 # Tells the extract script what files to look for L10n in and what
 # function handles the extraction. The Tower library expects this.
 DOMAIN_METHODS = {
-    'messages': [
+    'django': [
         ('%s/**.py' % PROJECT_MODULE,
          'tower.management.commands.extract.extract_tower_python'),
         ('%s/**/templates/**.html' % PROJECT_MODULE,


### PR DESCRIPTION
To test this, I....

1- Did an extract+merge and verified django.pot and all the django.po files were created.
2- I looked at the django.po files and they didn't have translations, as expected.
3- I copied locale/es/LC_MESSAGES/messages.po to locale/es/LC_MESSAGES/django.po
4- Compiled locales and ran the server.
5- Verified that /es/ is localized but /fr/, for example, isn't

I think that proves that all the parts are right. What did I miss?

r?
