### PR TITLE
[bug 1173763] Remove logging from sumosuggest provider

### DIFF
--- a/fjord/suggest/providers/sumosuggest.py
+++ b/fjord/suggest/providers/sumosuggest.py
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext as _
 import requests
 
 from fjord.base.google_utils import ga_track_event
-from fjord.journal.utils import j_info
 from fjord.suggest import Link, Suggester
 from fjord.redirector import Redirector, build_redirect_url
 
@@ -122,23 +121,6 @@ class SUMOSuggestRedirector(Redirector):
             except IndexError:
                 # This doc doesn't exist.
                 return
-
-        # FIXME: Putting this in here because I can't figure out
-        # what's going on with bug #1173763 and hoping this sheds some
-        # light. We'll take this out as soon as we identify the issue.
-        j_info(
-            app='suggest',
-            src='sumosuggest',
-            action='redirect',
-            msg='url is https:',
-            metadata={
-                'response_id': response_id,
-                'redirect': redirect,
-                'rank': rank,
-                'url': url,
-                'docs': docs
-            }
-        )
 
         ga_track_event({
             'cid': str(response_id),


### PR DESCRIPTION
For the last day, we logged all redirection urls in an attempt to see
whether Input was sending bad data to GA. After looking over 70+
entries, I see no evidence Input is sending bad data to GA.

Given that, I can only assume that Input is fine and GA is displaying
it incorrectly in the Event Flow report.

Given that, I'm removing the logging code.

Quick r?