### PR TITLE
[bug 1167192] Replace tower's activate().

### DIFF
--- a/fjord/base/l10n.py
+++ b/fjord/base/l10n.py
@@ -1,0 +1,13 @@
+from django.utils.translation import ugettext, ungettext
+
+
+def install_gettext():
+    """Install gettext into the Jinja2 environment."""
+    class Translation(object):
+        # We pass this object to jinja so it can use django's gettext
+        # implementation.
+        ugettext = staticmethod(ugettext)
+        ungettext = staticmethod(ungettext)
+
+    import jingo
+    jingo.env.install_gettext_translations(Translation)

--- a/fjord/base/middleware.py
+++ b/fjord/base/middleware.py
@@ -3,13 +3,13 @@ from warnings import warn
 
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
+from django.utils import translation
 from django.utils.encoding import smart_str
-
-import tower
 
 from fjord.base import urlresolvers
 from fjord.base.browsers import parse_ua
 from fjord.base.helpers import urlparams
+from fjord.base.l10n import install_gettext
 
 
 """
@@ -163,4 +163,5 @@ class LocaleURLMiddleware(object):
 
         request.path_info = '/' + prefixer.shortened_path
         request.locale = prefixer.locale
-        tower.activate(prefixer.locale)
+        translation.activate(prefixer.locale)
+        install_gettext()

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -308,7 +308,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 LOCALE_PATHS = (
-    os.path.join(ROOT, PROJECT_MODULE, 'locale'),
+    os.path.join(ROOT, 'locale'),
 )
 
 SUPPORTED_NONLOCALES = [


### PR DESCRIPTION
From the django docs, I'm pretty sure this is how you activate a locale. https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.translation.activate

Tower does a bunch of other stuff that I thought we didn't need. But this doesn't work. What am I missing?