### PR TITLE
[bug 1177451] Return safe (jinja2.Markup) strings from _()

### DIFF
--- a/fjord/base/l10n.py
+++ b/fjord/base/l10n.py
@@ -37,16 +37,28 @@ def strip_whitespace(message):
     return re.compile(r'\s+', re.UNICODE).sub(' ', message).strip()
 
 
+@jinja2.contextfunction
+def _gettext_alias(context, string, *args, **kw):
+    """Takes the result of gettext and marks it safe."""
+    return jinja2.Markup(
+        context.resolve('gettext')(string, *args, **kw))
+
+
 class MozInternationalizationExtension(InternationalizationExtension):
     """
     We override jinja2's _parse_block() to collapse whitespace so we can have
-    linebreaks wherever we want.
+    linebreaks wherever we want, and hijack _() to mark the result as safe.
     """
+
+    def __init__(self, environment):
+        super(MozInternationalizationExtension, self).__init__(environment)
+        environment.globals['_'] = _gettext_alias
 
     def _parse_block(self, parser, allow_pluralize):
         parse_block = InternationalizationExtension._parse_block
         ref, buffer = parse_block(self, parser, allow_pluralize)
         return ref, strip_whitespace(buffer)
+
 
 def tweak_message(message):
     """We piggyback on jinja2's babel_extract() (really, Babel's extract_*

--- a/fjord/base/tests/test_templates.py
+++ b/fjord/base/tests/test_templates.py
@@ -1,6 +1,6 @@
 from fjord.base.middleware import MOBILE_COOKIE
 
-from fjord.base.tests import eq_, LocalizingClient
+from fjord.base.tests import eq_, LocalizingClient, reverse
 from fjord.search.tests import ElasticTestCase
 
 
@@ -31,3 +31,17 @@ class MobileQueryStringOverrideTest(ElasticTestCase):
         })
         assert MOBILE_COOKIE in resp.cookies
         eq_(resp.cookies[MOBILE_COOKIE].value, 'no')
+
+
+class GettextStringTest(ElasticTestCase):
+    client_class = LocalizingClient
+
+    def test_gettext_in_templates(self):
+        """Verify that _() returns a safe string in templates."""
+        url = reverse('dashboard')
+        r = self.client.get(url)
+        eq_(200, r.status_code)
+
+        # The & shouldn't get escaped to &amp;
+        assert '&amp;raquo;' not in r.content
+        assert '&raquo;' in r.content


### PR DESCRIPTION
r?

I admit my testing was lazy. Should I do something different?