### PR TITLE
[bug 1187699] Fix q arg in secret histogram api

### DIFF
--- a/fjord/feedback/api_views.py
+++ b/fjord/feedback/api_views.py
@@ -88,7 +88,8 @@ class FeedbackHistogramAPI(rest_framework.views.APIView):
         search_query = request.GET.get('q', None)
         if search_query is not None:
             search = search.query(
-                'simple_query_string', description=search_query)
+                'simple_query_string', query=search_query,
+                fields=['description'])
 
         search = search.filter(f)
 


### PR DESCRIPTION
This adds a test and tweaks some test code to make adding the test easier. The actual fix is to make the `.query()` call correct.

Quick r?