### PR TITLE
[bug 1187505] Fix feedbackdev persistence code

### DIFF
--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -384,7 +384,7 @@ def persist_feedbackdev(fun):
         resp = fun(request, *args, **kwargs)
         if resp is not None and qs_feedbackdev is not None:
             resp.set_cookie(
-                waffle.settings.COOKIE_NAME % 'feedbackdev',
+                waffle.get_setting('COOKIE') % 'feedbackdev',
                 qs_feedbackdev)
 
         return resp


### PR DESCRIPTION
This fixes the feedbackdev persistence code. We upgraded django-waffle recently and they moved some stuff around internally. This code never got updated.

r?