### PR TITLE
Use the official Ubuntu vagrant box from Atlas

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,8 +33,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "trusty64"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "ubuntu/trusty64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
Replace the direct link to the Ubuntu box on Ubuntu download site with
the official vagrant box on Atlas. This helps with keeping up with the
box updates since Atlas supports box versioning.