### PR TITLE
[bug 1190356] Redo gengo machine translation

### DIFF
--- a/fjord/translations/admin.py
+++ b/fjord/translations/admin.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.module_loading import import_by_path
 
-from .gengo_utils import FjordGengo, GENGO_MACHINE_UNSUPPORTED
+from .gengo_utils import FjordGengo
 from .models import GengoJob, GengoOrder
 from .tasks import translate_tasks_by_id_list
 from .utils import locale_equals_language
@@ -135,7 +135,6 @@ def gengo_translator_view(request):
         'configured': configured,
         'settings': settings,
         'products': products,
-        'machine_unsupported': GENGO_MACHINE_UNSUPPORTED,
         'outstanding': outstanding,
         'seven_days_of_orders': seven_days_of_orders,
         'balance': balance,

--- a/fjord/translations/migrations/0002_gengojob_tier.py
+++ b/fjord/translations/migrations/0002_gengojob_tier.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('translations', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gengojob',
+            name='tier',
+            field=models.CharField(default='', max_length=10),
+            preserve_default=True,
+        ),
+    ]

--- a/fjord/translations/models.py
+++ b/fjord/translations/models.py
@@ -369,6 +369,10 @@ class GengoTranslationSystem(TranslationSystem):
     # Whether to should watch the balance when creating jobs
     gengo_watch_balance = False
 
+    # Whether to check if the src/dst is a supported pair--not all Gengo
+    # translation systems care about this
+    gengo_check_supported_language_pair = False
+
     def translate(self, instance, src_lang, src_field, dst_lang, dst_field):
         # If gengosystem is disabled, we just return immediately. We
         # can backfill later.
@@ -434,12 +438,9 @@ class GengoTranslationSystem(TranslationSystem):
                 metadata=metadata)
             return
 
-        # If this is 'standard' tier and if the src -> dst isn't a
-        # supported pair, log an issue for metrics purposes and move
-        # on. We only do this for 'standard' tier since the 'machine'
-        # tier has a different set of pairs which aren't available to
-        # us.
-        if ((self.gengo_tier == 'standard'
+        # If src/dst isn't a supported pair, log an issue for metrics
+        # purposes and move on.
+        if ((self.gengo_check_supported_language_pair
              and (lc_src, dst_lang) not in gengo_api.get_language_pairs())):
             self.log_error(
                 instance, action='translate',
@@ -629,6 +630,7 @@ class GengoHumanTranslator(GengoTranslationSystem):
     name = 'gengo_human'
     gengo_tier = 'standard'
     gengo_watch_balance = True
+    gengo_check_supported_language_pair = True
 
     def run_daily_activities(self):
         # If gengosystem is disabled, we don't want to do anything.

--- a/fjord/translations/templates/admin/gengo_translator_view.html
+++ b/fjord/translations/templates/admin/gengo_translator_view.html
@@ -89,14 +89,6 @@
       </table>
     </section>
     <section>
-      <h1>Unsupported machine languages</h1>
-      <table>
-        {% for lang in machine_unsupported %}
-          <tr><td>{{ lang }}</td></tr>
-        {% endfor %}
-      </table>
-    </section>
-    <section>
       <h1>Supported languages</h1>
       <table>
         <tr><th>Gengo language code (lc)</th><th>Gengo language</th><th>related prod locale</th></tr>


### PR DESCRIPTION
Gengo stopped doing synchronous machine translation so I rewrote the
code to do asynchronous translation. Because machine and human
translation are essentially the same now, I unified the two translation
systems and ditched a bunch of code.

r?