### PR TITLE
[bug 1195747] Handle "unknown" for country field in hb post

### DIFF
--- a/fjord/heartbeat/api_views.py
+++ b/fjord/heartbeat/api_views.py
@@ -41,6 +41,12 @@ class HeartbeatV2API(rest_framework.views.APIView):
     def post(self, request):
         post_data = dict(request.data)
 
+        # Stopgap fix for 1195747 where the hb client is sending
+        # "unknown" which fails validation because the column has
+        # max_length 4.
+        if post_data.get('country', '') == 'unknown':
+            post_data['country'] = 'UNK'
+
         serializer = AnswerSerializer(data=post_data)
         if not serializer.is_valid():
             return self.rest_error(post_data, serializer.errors)

--- a/fjord/heartbeat/tests/test_api.py
+++ b/fjord/heartbeat/tests/test_api.py
@@ -154,6 +154,32 @@ class HeartbeatPostAPITest(TestCase):
 
         eq_(ans.is_test, False)
 
+    def test_country_unknown(self):
+        """This is a stopgap fix for handling 'unknown' value for country"""
+        survey = SurveyFactory.create()
+
+        data = {
+            'experiment_version': '1',
+            'response_version': 1,
+            'person_id': 'joemamma',
+            'survey_id': survey.name,
+            'flow_id': '20141113',
+            'question_id': '1',
+            'updated_ts': self.timestamp(),
+
+            'question_text': 'ou812?',
+            'variation_id': '1',
+            'country': 'unknown'
+        }
+        resp = self.client.post(
+            reverse('heartbeat-api'),
+            content_type='application/json',
+            data=json.dumps(data))
+
+        eq_(resp.status_code, 201)
+        ans = Answer.objects.latest('id')
+        eq_(ans.country, 'UNK')
+
     def test_survey_doesnt_exist(self):
         """If the survey doesn't exist, kick up an error"""
         data = {


### PR DESCRIPTION
This is a stop gap fix to handle "unknown" as a value for the country
field for HB posts. What's going on now is that it throws an HTTP 400
error. This fixes it so that "unknown" gets changed to "UNK" which is a
valid value.

Ultimately we should fix this in HB. There's a PR to fix it there. Once
it's fixed there, we can undo this change.

r?