### PR TITLE
[bug 1192812] Fix firefox for ios inferring

### DIFF
--- a/fjord/base/browsers.py
+++ b/fjord/base/browsers.py
@@ -105,7 +105,7 @@ def parse_ua(ua):
     platform = platform_parts.pop(0)
     platform_version = UNKNOWN
 
-    while platform in ['X11', 'Ubuntu', 'U', 'iPad', 'iPhone']:
+    while platform in ['X11', 'Ubuntu', 'U', 'iPod touch', 'iPad', 'iPhone']:
         platform = platform_parts.pop(0)
 
     if platform == 'Windows':

--- a/fjord/base/tests/user_agent_data.json
+++ b/fjord/base/tests/user_agent_data.json
@@ -190,5 +190,13 @@
     "platform": "iPhone OS",
     "platform_version": "8.3",
     "mobile": true
+  },
+  {
+    "user_agent": "Mozilla/5.0 (iPod touch; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12H143 Safari/600.1.4",
+    "browser": "Firefox for iOS",
+    "browser_version": "1.0",
+    "platform": "iPhone OS",
+    "platform_version": "8.4",
+    "mobile": true
   }
 ]


### PR DESCRIPTION
What's going on is that I had handling for iPhone and iPad, but not iPod touch. I fixed that and also added some tests to verify that inferring works correctly.

r?