### PR TITLE
[bug 1192812] Fix platform inferring for firefox for ios

### DIFF
--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -403,6 +403,9 @@ class Response(ModelBase):
                 return browser.platform + ' ' + browser.platform_version
             return browser.platform
 
+        elif product == u'Firefox for iOS':
+            return browser.platform + ' ' + browser.platform_version
+
         return u''
 
 

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -411,6 +411,7 @@ class TestFeedback(TestCase):
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.locale == 'en-US'
         assert feedback.product == 'Firefox for iOS'
+        assert feedback.platform == 'iPhone OS 8.4'
         assert feedback.browser == 'Firefox for iOS'
         assert feedback.browser_version == '1.0'
         assert feedback.browser_platform == 'iPhone OS'


### PR DESCRIPTION
I missed this in the previous fix. Bah.

I'll wait for Travis to greenlight it and then self-r+ it and land it.