### PR TITLE
bug 1193323 : Remove eq_ and ok_ : base

### DIFF
--- a/fjord/base/tests/test_auth.py
+++ b/fjord/base/tests/test_auth.py
@@ -5,7 +5,6 @@ from django.test.client import RequestFactory
 from fjord.base.browserid import FjordVerify
 from fjord.base.tests import (
     BaseTestCase,
-    eq_,
     ProfileFactory,
     reverse,
     UserFactory
@@ -35,9 +34,9 @@ class TestAuth(BaseTestCase):
         fv.request = post_request
 
         resp = fv.login_success()
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
         body = json.loads(resp.content)
-        eq_(body['redirect'], reverse('new-user-view'))
+        assert body['redirect'] == reverse('new-user-view')
 
     def test_existing_user(self):
         """Tests that existing users get redirected to right place"""
@@ -60,9 +59,9 @@ class TestAuth(BaseTestCase):
         fv.request = post_request
 
         resp = fv.login_success()
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
         body = json.loads(resp.content)
-        eq_(body['redirect'], '/')
+        assert body['redirect'] == '/'
 
         # Now do it with next!
         post_request = RequestFactory().post(
@@ -76,6 +75,6 @@ class TestAuth(BaseTestCase):
         fv.request = post_request
 
         resp = fv.login_success()
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
         body = json.loads(resp.content)
-        eq_(body['redirect'], '/foo')
+        assert body['redirect'] == '/foo'

--- a/fjord/base/tests/test_browsers.py
+++ b/fjord/base/tests/test_browsers.py
@@ -4,7 +4,6 @@ import os
 from django import test
 
 from fjord.base import browsers, middleware
-from fjord.base.tests import eq_
 
 
 class TestUserAgentDetection(object):
@@ -58,4 +57,4 @@ class TestUserAgentDetection(object):
         assert(hasattr(request, 'BROWSER'))
         for k, v in checks.items():
             assert(hasattr(request.BROWSER, k))
-            eq_(getattr(request.BROWSER, k), v)
+            assert getattr(request.BROWSER, k) == v

--- a/fjord/base/tests/test_domain.py
+++ b/fjord/base/tests/test_domain.py
@@ -1,5 +1,5 @@
 from fjord.base.domain import get_domain
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 
 
 class TestGetDomain(TestCase):
@@ -36,4 +36,4 @@ class TestGetDomain(TestCase):
         ]
 
         for data, expected in testdata:
-            eq_(get_domain(data), expected)
+            assert get_domain(data) == expected

--- a/fjord/base/tests/test_forms.py
+++ b/fjord/base/tests/test_forms.py
@@ -2,7 +2,6 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from fjord.base.forms import EnhancedURLField
-from fjord.base.tests import eq_
 
 
 class EnhancedURLFieldTests(TestCase):
@@ -33,7 +32,7 @@ class EnhancedURLFieldTests(TestCase):
 
         for expected, url in test_data:
             try:
-                eq_(f.clean(url), expected)
+                assert f.clean(url) == expected
             except ValidationError:
                 print url
                 raise
@@ -64,4 +63,4 @@ class EnhancedURLFieldTests(TestCase):
             try:
                 f.clean(url)
             except ValidationError as exc:
-                eq_(exc.messages, [msg])
+                assert exc.messages == [msg]

--- a/fjord/base/tests/test_google_utils.py
+++ b/fjord/base/tests/test_google_utils.py
@@ -5,7 +5,7 @@ import requests_mock
 from mock import MagicMock, patch
 
 from fjord.base.google_utils import GOOGLE_API_URL, ga_track_event
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 
 
 def set_sys_argv(sys_argv):
@@ -86,7 +86,7 @@ class GoogleUtilsTestCase(TestCase):
             with patch(d) as delay_patch:
                 params = {'cid': 'xxx', 'ec': 'ou812'}
                 ga_track_event(params, async=True)
-                eq_(delay_patch.call_count, 1)
+                assert delay_patch.call_count == 1
 
     def test_ga_track_event_async_false(self):
         """async=False, then delay() never gets called"""
@@ -97,4 +97,4 @@ class GoogleUtilsTestCase(TestCase):
             with patch(d) as delay_patch:
                 params = {'cid': 'xxx', 'ec': 'ou812'}
                 ga_track_event(params, async=False)
-                eq_(delay_patch.call_count, 0)
+                assert delay_patch.call_count == 0

--- a/fjord/base/tests/test_helpers.py
+++ b/fjord/base/tests/test_helpers.py
@@ -1,5 +1,5 @@
 from fjord.base.helpers import locale_name
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 
 
 class TestLocaleName(TestCase):
@@ -11,7 +11,7 @@ class TestLocaleName(TestCase):
             (u'xx', u'Unknown')
         ]
         for name, expected in data:
-            eq_(unicode(locale_name(name)), expected)
+            assert unicode(locale_name(name)) == expected
 
     def test_native(self):
         data = [
@@ -21,4 +21,4 @@ class TestLocaleName(TestCase):
             (u'xx', u'Unknown')
         ]
         for name, expected in data:
-            eq_(unicode(locale_name(name, native=True)), expected)
+            assert unicode(locale_name(name, native=True)) == expected

--- a/fjord/base/tests/test_templates.py
+++ b/fjord/base/tests/test_templates.py
@@ -1,6 +1,6 @@
 from fjord.base.middleware import MOBILE_COOKIE
 
-from fjord.base.tests import eq_, LocalizingClient, reverse
+from fjord.base.tests import LocalizingClient, reverse
 from fjord.search.tests import ElasticTestCase
 
 
@@ -24,13 +24,13 @@ class MobileQueryStringOverrideTest(ElasticTestCase):
             'mobile': 1
         })
         assert MOBILE_COOKIE in resp.cookies
-        eq_(resp.cookies[MOBILE_COOKIE].value, 'yes')
+        assert resp.cookies[MOBILE_COOKIE].value == 'yes'
 
         resp = self.client.get('/', {
             'mobile': 0
         })
         assert MOBILE_COOKIE in resp.cookies
-        eq_(resp.cookies[MOBILE_COOKIE].value, 'no')
+        assert resp.cookies[MOBILE_COOKIE].value == 'no'
 
 
 class GettextStringTest(ElasticTestCase):
@@ -40,7 +40,7 @@ class GettextStringTest(ElasticTestCase):
         """Verify that _() returns a safe string in templates."""
         url = reverse('dashboard')
         r = self.client.get(url)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
 
         # The & shouldn't get escaped to &amp;
         assert '&amp;raquo;' not in r.content

--- a/fjord/base/tests/test_urlresolvers.py
+++ b/fjord/base/tests/test_urlresolvers.py
@@ -1,4 +1,4 @@
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 from fjord.base.urlresolvers import reverse
 
 
@@ -8,9 +8,9 @@ class TestReverse(TestCase):
         # then it breaks this test. But it seems silly to do a bunch
         # of work to set up a better less fragile test plus it's
         # unlikely we'll change the 'about' view.
-        eq_(reverse('about-view'), '/en-US/about')
+        assert reverse('about-view') == '/en-US/about'
 
     def test_locale(self):
         # Note: This depends on the 'about' view and the 'es'
         # locale. If we change those, then it breaks this test.
-        eq_(reverse('about-view', locale='es'), '/es/about')
+        assert reverse('about-view', locale='es') == '/es/about'

--- a/fjord/base/tests/test_utils.py
+++ b/fjord/base/tests/test_utils.py
@@ -3,7 +3,7 @@ import datetime
 
 from django.test.client import RequestFactory
 
-from fjord.base.tests import eq_, ok_, reverse, TestCase
+from fjord.base.tests import reverse, TestCase
 from fjord.base.utils import (
     actual_ip_plus_context,
     instance_to_key,
@@ -19,68 +19,68 @@ from fjord.base.utils import (
 
 
 def test_smart_truncate():
-    eq_(smart_truncate(u''), u'')
-    eq_(smart_truncate(u'abc'), u'abc')
-    eq_(smart_truncate(u'abc def', length=4), u'abc...')
-    eq_(smart_truncate(u'abcdef', length=4), u'abcd...')
-    eq_(smart_truncate(u'ééé ééé', length=4), u'ééé...')
+    assert smart_truncate(u'') == u''
+    assert smart_truncate(u'abc') == u'abc'
+    assert smart_truncate(u'abc def', length=4) == u'abc...'
+    assert smart_truncate(u'abcdef', length=4) == u'abcd...'
+    assert smart_truncate(u'ééé ééé', length=4) == u'ééé...'
 
 
 class SmartStrTestCase(TestCase):
     def test_str(self):
-        eq_('a', smart_str('a'))
-        eq_(u'a', smart_str(u'a'))
+        assert 'a' == smart_str('a')
+        assert u'a' == smart_str(u'a')
 
     def test_not_str(self):
-        eq_(u'', smart_str(1))
-        eq_(u'', smart_str(1.1))
-        eq_(u'', smart_str(True))
-        eq_(u'', smart_str(['a']))
+        assert u'' == smart_str(1)
+        assert u'' == smart_str(1.1)
+        assert u'' == smart_str(True)
+        assert u'' == smart_str(['a'])
 
-        eq_(u'', smart_str(None))
+        assert u'' == smart_str(None)
 
 
 class SmartIntTestCase(TestCase):
     def test_sanity(self):
-        eq_(10, smart_int('10'))
-        eq_(10, smart_int('10.5'))
+        assert 10 == smart_int('10')
+        assert 10 == smart_int('10.5')
 
     def test_int(self):
-        eq_(10, smart_int(10))
+        assert 10 == smart_int(10)
 
     def test_invalid_string(self):
-        eq_(0, smart_int('invalid'))
+        assert 0 == smart_int('invalid')
 
     def test_empty_string(self):
-        eq_(0, smart_int(''))
+        assert 0 == smart_int('')
 
     def test_wrong_type(self):
-        eq_(0, smart_int(None))
-        eq_(10, smart_int([], 10))
+        assert 0 == smart_int(None)
+        assert 10 == smart_int([], 10)
 
     def test_overflow(self):
-        eq_(0, smart_int('1e309'))
+        assert 0 == smart_int('1e309')
 
 
 class SmartDateTest(TestCase):
     def test_sanity(self):
-        eq_(datetime.date(2012, 1, 1), smart_date('2012-01-01'))
-        eq_(None, smart_date('1742-11-05'))
-        eq_(None, smart_date('0001-01-01'))
+        assert datetime.date(2012, 1, 1) == smart_date('2012-01-01')
+        assert None == smart_date('1742-11-05')
+        assert None == smart_date('0001-01-01')
 
     def test_empty_string(self):
-        eq_(None, smart_date(''))
+        assert None == smart_date('')
 
     def test_date(self):
-        eq_(datetime.date(2012, 1, 1), smart_date('2012-01-01'))
-        eq_(datetime.date(2012, 1, 1), smart_date('2012-1-1'))
+        assert datetime.date(2012, 1, 1) == smart_date('2012-01-01')
+        assert datetime.date(2012, 1, 1) == smart_date('2012-1-1')
 
     def test_fallback(self):
-        eq_('Hullaballo', smart_date('', fallback='Hullaballo'))
+        assert 'Hullaballo' == smart_date('', fallback='Hullaballo')
 
     def test_null_bytes(self):
         # strptime likes to barf on null bytes in strings, so test it.
-        eq_(None, smart_date('/etc/passwd\x00'))
+        assert None == smart_date('/etc/passwd\x00')
 
 
 class SmartBoolTest(TestCase):
@@ -108,13 +108,13 @@ class SmartBoolTest(TestCase):
 
 class SmartTimeDeltaTest(TestCase):
     def test_valid(self):
-        eq_(smart_timedelta('1d'), datetime.timedelta(days=1))
-        eq_(smart_timedelta('14d'), datetime.timedelta(days=14))
+        assert smart_timedelta('1d') == datetime.timedelta(days=1)
+        assert smart_timedelta('14d') == datetime.timedelta(days=14)
 
     def test_invalid(self):
-        eq_(smart_timedelta('0d', 'fallback'), 'fallback')
-        eq_(smart_timedelta('foo', 'fallback'), 'fallback')
-        eq_(smart_timedelta('d', 'fallback'), 'fallback')
+        assert smart_timedelta('0d', 'fallback') == 'fallback'
+        assert smart_timedelta('foo', 'fallback') == 'fallback'
+        assert smart_timedelta('d', 'fallback') == 'fallback'
 
 
 class WrapWithParagraphsTest(TestCase):
@@ -128,7 +128,7 @@ class WrapWithParagraphsTest(TestCase):
         ]
 
         for arg, width, expected in test_data:
-            eq_(wrap_with_paragraphs(arg, width), expected)
+            assert wrap_with_paragraphs(arg, width) == expected
 
     def test_edge_cases(self):
         test_data = [
@@ -137,7 +137,7 @@ class WrapWithParagraphsTest(TestCase):
         ]
 
         for arg, width, expected in test_data:
-            eq_(wrap_with_paragraphs(arg, width), expected)
+            assert wrap_with_paragraphs(arg, width) == expected
 
 
 _foo_cache = {}
@@ -165,12 +165,13 @@ class TestKeys(TestCase):
 
     def test_instance_to_key(self):
         foo = FakeModel(15)
-        eq_(instance_to_key(foo), 'fjord.base.tests.test_utils:FakeModel:15')
+        key = 'fjord.base.tests.test_utils:FakeModel:15'
+        assert instance_to_key(foo) == key
 
     def test_key_to_instance(self):
         foo = FakeModel(15)
         key = 'fjord.base.tests.test_utils:FakeModel:15'
-        eq_(key_to_instance(key), foo)
+        assert key_to_instance(key) == foo
 
 
 class TestActualIPPlusContext(TestCase):
@@ -192,10 +193,10 @@ class TestActualIPPlusContext(TestCase):
 
         # Key can't exceed memcached 250 character max
         length = len(key)
-        ok_(length < 250)
+        assert length < 250
 
         # Key must be a string
-        ok_(isinstance(key, str))
+        assert isinstance(key, str)
 
         # create a request with this as the description
         second_desc = u'\u62e9\u201c\u5728\u65b0\u6807\u7b7e\u9875\u4e2d' * 16
@@ -227,4 +228,4 @@ class TestActualIPPlusContext(TestCase):
 
         # Key can't exceed memcached 250 character max
         length = len(key)
-        ok_(length < 250)
+        assert length < 250

--- a/fjord/base/tests/test_views.py
+++ b/fjord/base/tests/test_views.py
@@ -7,7 +7,6 @@ from pyquery import PyQuery
 
 from fjord.base import views
 from fjord.base.tests import (
-    eq_,
     LocalizingClient,
     TestCase,
     AnalyzerProfileFactory,
@@ -22,18 +21,18 @@ class TestAbout(TestCase):
 
     def test_about_view(self):
         r = self.client.get(reverse('about-view'))
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'about.html')
 
 
 class TestLoginFailure(TestCase):
     def test_login_failure_view(self):
         r = self.client.get(reverse('login-failure'))
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'login_failure.html')
 
         r = self.client.get(reverse('login-failure'), {'mobile': 1})
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'mobile/login_failure.html')
 
 
@@ -73,8 +72,8 @@ class MonitorViewTest(ElasticTestCase):
                 errors = [line for line in resp.content.splitlines()
                           if 'ERROR' in line]
 
-                eq_(resp.status_code, 200, '%s != %s (%s)' % (
-                    resp.status_code, 200, repr(errors)))
+                assert resp.status_code == 200, '%s != %s (%s)' % (
+                    resp.status_code, 200, repr(errors))
 
         finally:
             views.test_memcached = test_memcached
@@ -85,7 +84,7 @@ class FileNotFoundTesting(TestCase):
 
     def test_404(self):
         request = self.client.get('/a/path/that/should/never/exist')
-        eq_(request.status_code, 404)
+        assert request.status_code == 404
         self.assertTemplateUsed(request, '404.html')
 
 
@@ -95,13 +94,13 @@ class ServerErrorTesting(TestCase):
         with self.assertRaises(IntentionalException) as cm:
             self.client.get('/services/throw-error')
 
-        eq_(type(cm.exception), IntentionalException)
+        assert type(cm.exception) == IntentionalException
 
 
 class TestRobots(TestCase):
     def test_robots(self):
         resp = self.client.get('/robots.txt')
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateUsed(resp, 'robots.txt')
 
 
@@ -109,7 +108,7 @@ class TestContribute(TestCase):
 
     def test_contribute(self):
         resp = self.client.get('/contribute.json')
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateUsed(resp, 'contribute.json')
 
     def test_contribute_if_valid_json(self):
@@ -128,20 +127,20 @@ class TestNewUserView(ElasticTestCase):
         # AnonymousUser shouldn't get to the new-user-view, so make
         # sure they get redirected to the dashboard.
         resp = self.client.get(reverse('new-user-view'), follow=True)
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateNotUsed('new_user.html')
         self.assertTemplateUsed('analytics/dashboard.html')
 
     def test_default_next_url(self):
         self.client_login_user(self.jane)
         resp = self.client.get(reverse('new-user-view'))
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateUsed('new_user.html')
 
         # Pull out next link
         pq = PyQuery(resp.content)
         next_url = pq('#next-url-link')
-        eq_(next_url.attr['href'], '/en-US/')  # this is the dashboard
+        assert next_url.attr['href'] == '/en-US/'  # this is the dashboard
 
     def test_valid_next_url(self):
         self.client_login_user(self.jane)
@@ -149,14 +148,14 @@ class TestNewUserView(ElasticTestCase):
         resp = self.client.get(url, {
             'next': '/ou812'  # stretches the meaning of 'valid'
         })
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateUsed('new_user.html')
 
         # Pull out next link which is naughty, so it should have been
         # replaced with a dashboard link.
         pq = PyQuery(resp.content)
         next_url = pq('#next-url-link')
-        eq_(next_url.attr['href'], '/ou812')
+        assert next_url.attr['href'] == '/ou812'
 
     def test_sanitized_next_url(self):
         self.client_login_user(self.jane)
@@ -164,11 +163,11 @@ class TestNewUserView(ElasticTestCase):
         resp = self.client.get(url, {
             'next': 'javascript:prompt%28document.cookie%29'
         })
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateUsed('new_user.html')
 
         # Pull out next link which is naughty, so it should have been
         # replaced with a dashboard link.
         pq = PyQuery(resp.content)
         next_url = pq('#next-url-link')
-        eq_(next_url.attr['href'], '/en-US/')  # this is the dashboard
+        assert next_url.attr['href'] == '/en-US/'  # this is the dashboard


### PR DESCRIPTION
This commit removes eq_ and ok_ imports as well as their use in the
files. It replaces eq_ and ok_ with proper assert statements.