### PR TITLE
[bug 1193321] Remove eq_ and ok_: analytics

### DIFF
--- a/fjord/analytics/tests/test_analyzer_views.py
+++ b/fjord/analytics/tests/test_analyzer_views.py
@@ -6,8 +6,6 @@ from pyquery import PyQuery
 from django.contrib.auth.models import Group
 
 from fjord.base.tests import (
-    eq_,
-    ok_,
     LocalizingClient,
     AnalyzerProfileFactory,
     reverse
@@ -26,12 +24,12 @@ class TestAnalyticsDashboardView(ElasticTestCase):
         # Verifies that only analyzers can see the analytics dashboard
         # link
         resp = self.client.get(reverse('dashboard'))
-        eq_(200, resp.status_code)
+        assert 200 == resp.status_code
         assert 'adashboard' not in resp.content
 
         # Verifies that only analyzers can see the analytics dashboard
         resp = self.client.get(reverse('analytics_dashboard'))
-        eq_(403, resp.status_code)
+        assert 403 == resp.status_code
 
         # Verify analyzers can see analytics dashboard link
         jane = AnalyzerProfileFactory(user__email='jane@example.com').user
@@ -39,12 +37,12 @@ class TestAnalyticsDashboardView(ElasticTestCase):
         self.client_login_user(jane)
 
         resp = self.client.get(reverse('dashboard'))
-        eq_(200, resp.status_code)
+        assert 200 == resp.status_code
         assert 'adashboard' in resp.content
 
         # Verify analyzers can see analytics dashboard
         resp = self.client.get(reverse('analytics_dashboard'))
-        eq_(200, resp.status_code)
+        assert 200 == resp.status_code
 
 
 class TestSearchView(ElasticTestCase):
@@ -118,71 +116,71 @@ class TestSearchView(ElasticTestCase):
 
     def test_front_page(self):
         r = self.client.get(self.url)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/analyzer/search.html')
 
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
     def test_search(self):
         # Happy
         r = self.client.get(self.url, {'happy': 1})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 4)
+        assert len(pq('li.opinion')) == 4
 
         # Sad
         r = self.client.get(self.url, {'happy': 0})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 3)
+        assert len(pq('li.opinion')) == 3
 
         # Locale
         r = self.client.get(self.url, {'locale': 'es'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 2)
+        assert len(pq('li.opinion')) == 2
 
         # Platform and happy
         r = self.client.get(self.url, {'happy': 1, 'platform': 'Linux'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 2)
+        assert len(pq('li.opinion')) == 2
 
         # Product
         r = self.client.get(self.url, {'product': 'Firefox'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         # Product
         r = self.client.get(self.url, {'product': 'Firefox for Android'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         # Product version
         r = self.client.get(
             self.url, {'product': 'Firefox', 'version': '17.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         # Product version
         r = self.client.get(
             self.url, {'product': 'Firefox', 'version': '18.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         # Empty search
         r = self.client.get(self.url, {'platform': 'Atari'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
     def test_has_email(self):
         # Test before we create a responsemail
         r = self.client.get(self.url, {'has_email': '0'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         r = self.client.get(self.url, {'has_email': '1'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         ResponseEmailFactory(
             opinion__happy=True,
@@ -196,16 +194,16 @@ class TestSearchView(ElasticTestCase):
         self.setup_indexes()
 
         r = self.client.get(self.url, {'has_email': '0'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        ok_('ou812' not in r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert 'ou812' not in r.content
+        assert len(pq('li.opinion')) == 7
 
         r = self.client.get(self.url, {'has_email': '1'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        ok_('ou812' in r.content)
-        eq_(len(pq('li.opinion')), 1)
+        assert 'ou812' in r.content
+        assert len(pq('li.opinion')) == 1
 
     def test_country(self):
         ResponseEmailFactory(
@@ -221,23 +219,23 @@ class TestSearchView(ElasticTestCase):
 
         r = self.client.get(self.url, {
             'product': 'Firefox OS', 'country': 'ES'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        ok_('ou812' in r.content)
-        eq_(len(pq('li.opinion')), 1)
+        assert 'ou812' in r.content
+        assert len(pq('li.opinion')) == 1
 
     def test_empty_and_unknown(self):
         # Empty value should work
         r = self.client.get(self.url, {'platform': ''})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 1)
+        assert len(pq('li.opinion')) == 1
 
         # "Unknown" value should also work
         r = self.client.get(self.url, {'platform': 'Unknown'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 1)
+        assert len(pq('li.opinion')) == 1
 
     def test_version_noop(self):
         """version has no effect if product isn't set"""
@@ -246,31 +244,31 @@ class TestSearchView(ElasticTestCase):
         r = self.client.get(
             self.url, {'product': 'Firefox', 'version': '18.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         # Filter on version--filter has no effect on results
         r = self.client.get(
             self.url, {'version': '18.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
     def test_text_search(self):
         # Text search
         r = self.client.get(self.url, {'q': 'apple'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 3)
+        assert len(pq('li.opinion')) == 3
 
         # Text and filter
         r = self.client.get(
             self.url, {'q': 'apple', 'happy': 1, 'locale': 'en-US'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 2)
+        assert len(pq('li.opinion')) == 2
 
     def test_text_search_unicode(self):
         """Unicode in the search field shouldn't kick up errors"""
         # Text search
         r = self.client.get(self.url, {'q': u'\u2713'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
     def test_date_search(self):
         # These start and end dates will give known slices of the data.
@@ -283,14 +281,14 @@ class TestSearchView(ElasticTestCase):
             'date_end': end,
         })
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 5)
+        assert len(pq('li.opinion')) == 5
 
         # Unspecified end => [start, +infin)
         r = self.client.get(self.url, {
             'date_start': start
         })
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 6)
+        assert len(pq('li.opinion')) == 6
 
         # Both start and end => [start, end]
         r = self.client.get(self.url, {
@@ -298,27 +296,27 @@ class TestSearchView(ElasticTestCase):
             'date_end': end,
         })
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 4)
+        assert len(pq('li.opinion')) == 4
 
     def test_date_start_valueerror(self):
         # https://bugzilla.mozilla.org/show_bug.cgi?id=898584
         r = self.client.get(self.url, {
             'date_start': '0001-01-01',
         })
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
     def test_invalid_search(self):
         # Invalid values for happy shouldn't filter
         r = self.client.get(self.url, {'happy': 'fish'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         # Unknown parameters should be ignored.
         r = self.client.get(self.url, {'apples': 'oranges'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         # A broken date range search shouldn't affect anything
         # Why this? Because this is the thing the fuzzer found.
@@ -326,16 +324,16 @@ class TestSearchView(ElasticTestCase):
             'date_end': '/etc/shadow\x00',
             'date_start': '/etc/passwd\x00'
         })
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
     def test_search_export_csv(self):
         r = self.client.get(self.url, {'format': 'csv'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
         # Check that it parses in csv with n rows.
         lines = r.content.splitlines()
 
         # URL row, params row, header row and one row for every opinion
-        eq_(len(lines), 10)
+        assert len(lines) == 10

--- a/fjord/analytics/tests/test_utils.py
+++ b/fjord/analytics/tests/test_utils.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from unittest import TestCase
 
 from fjord.analytics.utils import counts_to_options, zero_fill
-from fjord.base.tests import eq_
 from fjord.base.utils import epoch_milliseconds
 
 
@@ -14,30 +13,30 @@ class TestCountsHelper(TestCase):
         """Correct options should be set and values should be sorted.
         """
         options = counts_to_options(self.counts, 'fruit', 'Fruit')
-        eq_(options['name'], 'fruit')
-        eq_(options['display'], 'Fruit')
+        assert options['name'] == 'fruit'
+        assert options['display'] == 'Fruit'
 
-        eq_(options['options'][0], {
+        assert options['options'][0] == {
             'name': 'bananas',
             'display': 'bananas',
             'value': 'bananas',
             'count': 10,
             'checked': False,
-        })
-        eq_(options['options'][1], {
+        }
+        assert options['options'][1] == {
             'name': 'oranges',
             'display': 'oranges',
             'value': 'oranges',
             'count': 6,
             'checked': False,
-        })
-        eq_(options['options'][2], {
+        }
+        assert options['options'][2] == {
             'name': 'apples',
             'display': 'apples',
             'value': 'apples',
             'count': 5,
             'checked': False,
-        })
+        }
 
     def test_map_dict(self):
         options = counts_to_options(self.counts, 'fruit', display_map={
@@ -46,17 +45,17 @@ class TestCountsHelper(TestCase):
             'oranges': 'Oranges',
         })
         # Note that options get sorted by count.
-        eq_(options['options'][0]['display'], 'Bananas')
-        eq_(options['options'][1]['display'], 'Oranges')
-        eq_(options['options'][2]['display'], 'Apples')
+        assert options['options'][0]['display'] == 'Bananas'
+        assert options['options'][1]['display'] == 'Oranges'
+        assert options['options'][2]['display'] == 'Apples'
 
     def test_map_func(self):
         options = counts_to_options(self.counts, 'fruit',
                                     value_map=lambda s: s.upper())
         # Note that options get sorted by count.
-        eq_(options['options'][0]['value'], 'BANANAS')
-        eq_(options['options'][1]['value'], 'ORANGES')
-        eq_(options['options'][2]['value'], 'APPLES')
+        assert options['options'][0]['value'] == 'BANANAS'
+        assert options['options'][1]['value'] == 'ORANGES'
+        assert options['options'][2]['value'] == 'APPLES'
 
     def test_checked(self):
         options = counts_to_options(self.counts, 'fruit', checked='apples')

--- a/fjord/analytics/tests/test_views.py
+++ b/fjord/analytics/tests/test_views.py
@@ -10,7 +10,6 @@ from django.http import QueryDict
 
 from fjord.analytics import views
 from fjord.base.tests import (
-    eq_,
     LocalizingClient,
     AnalyzerProfileFactory,
     reverse,
@@ -55,13 +54,13 @@ class TestDashboardView(ElasticTestCase):
     def test_front_page(self):
         url = reverse('dashboard')
         r = self.client.get(url)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/dashboard.html')
 
         pq = PyQuery(r.content)
         # Make sure that each opinion is shown and that the count is correct.
-        eq_(pq('.block.count strong').text(), '7')
-        eq_(len(pq('li.opinion')), 7)
+        assert pq('.block.count strong').text() == '7'
+        assert len(pq('li.opinion')) == 7
 
     def test_hidden_products_dont_show_up(self):
         # Create a hidden product and one response for it
@@ -73,7 +72,7 @@ class TestDashboardView(ElasticTestCase):
 
         url = reverse('dashboard')
         resp = self.client.get(url)
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
 
         assert 'HiddenProduct' not in resp.content
 
@@ -96,28 +95,28 @@ class TestDashboardView(ElasticTestCase):
     def test_dashboard_atom_links(self):
         """Test dashboard atom links are correct"""
         r = self.client.get(reverse('dashboard'))
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         assert '/en-US/?format=atom' in r.content
 
         r = self.client.get(
             reverse('dashboard'),
             {'happy': 1})
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         pq = PyQuery(r.content)
         pq = pq('link[type="application/atom+xml"]')
         qs = QueryDict(pq[0].attrib['href'].split('?')[1])
-        eq_(qs['happy'], u'1')
-        eq_(qs['format'], u'atom')
+        assert qs['happy'] == u'1'
+        assert qs['format'] == u'atom'
 
         r = self.client.get(
             reverse('dashboard'),
             {'product': 'Firefox', 'version': '20.0'})
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         pq = PyQuery(r.content)
         pq = pq('link[type="application/atom+xml"]')
         qs = QueryDict(pq[0].attrib['href'].split('?')[1])
-        eq_(qs['product'], u'Firefox')
-        eq_(qs['version'], u'20.0')
+        assert qs['product'] == u'Firefox'
+        assert qs['version'] == u'20.0'
 
     def test_truncated_description_on_dashboard(self):
         # Create a description that's 500 characters long (which is
@@ -136,64 +135,64 @@ class TestDashboardView(ElasticTestCase):
         # Happy
         r = self.client.get(url, {'happy': 1})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 4)
+        assert len(pq('li.opinion')) == 4
 
         # Sad
         r = self.client.get(url, {'happy': 0})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 3)
+        assert len(pq('li.opinion')) == 3
 
         # Locale
         r = self.client.get(url, {'locale': 'es'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 2)
+        assert len(pq('li.opinion')) == 2
 
         # Platform and happy
         r = self.client.get(url, {'happy': 1, 'platform': 'Linux'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 2)
+        assert len(pq('li.opinion')) == 2
 
         # Product
         r = self.client.get(url, {'product': 'Firefox'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         # Product
         r = self.client.get(url, {'product': 'Firefox for Android'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         # Product version
         r = self.client.get(
             url, {'product': 'Firefox', 'version': '17.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
         # Product version
         r = self.client.get(
             url, {'product': 'Firefox', 'version': '18.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         # Empty search
         r = self.client.get(url, {'platform': 'Atari'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
     def test_empty_and_unknown(self):
         url = reverse('dashboard')
 
         # Empty value should work
         r = self.client.get(url, {'platform': ''})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 1)
+        assert len(pq('li.opinion')) == 1
 
         # "Unknown" value should also work
         r = self.client.get(url, {'platform': 'Unknown'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 1)
+        assert len(pq('li.opinion')) == 1
 
     def test_version_noop(self):
         """version has no effect if product isn't set"""
@@ -204,49 +203,49 @@ class TestDashboardView(ElasticTestCase):
         r = self.client.get(
             url, {'product': 'Firefox', 'version': '18.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 0)
+        assert len(pq('li.opinion')) == 0
 
         # Filter on version--filter has no effect on results
         r = self.client.get(
             url, {'version': '18.0'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
     def test_text_search(self):
         url = reverse('dashboard')
         # Text search
         r = self.client.get(url, {'q': 'apple'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 3)
+        assert len(pq('li.opinion')) == 3
         # Text and filter
         r = self.client.get(url, {'q': 'apple', 'happy': 1, 'locale': 'en-US'})
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 2)
+        assert len(pq('li.opinion')) == 2
 
     def test_text_search_unicode(self):
         """Unicode in the search field shouldn't kick up errors"""
         url = reverse('dashboard')
         # Text search
         r = self.client.get(url, {'q': u'\u2713'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
     def test_search_format_json(self):
         """JSON output works"""
         url = reverse('dashboard')
         # Text search
         r = self.client.get(url, {'q': u'apple', 'format': 'json'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
         content = json.loads(r.content)
-        eq_(content['total'], 3)
-        eq_(len(content['results']), 3)
+        assert content['total'] == 3
+        assert len(content['results']) == 3
 
     def test_search_format_atom(self):
         """Atom output works"""
         url = reverse('dashboard')
         # Text search
         r = self.client.get(url, {'q': u'apple', 'format': 'atom'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
         assert 'http://www.w3.org/2005/Atom' in r.content
 
@@ -262,14 +261,14 @@ class TestDashboardView(ElasticTestCase):
             'date_end': end,
         })
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 5)
+        assert len(pq('li.opinion')) == 5
 
         # Unspecified end => [start, +infin)
         r = self.client.get(url, {
             'date_start': start
         })
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 6)
+        assert len(pq('li.opinion')) == 6
 
         # Both start and end => [start, end]
         r = self.client.get(url, {
@@ -277,7 +276,7 @@ class TestDashboardView(ElasticTestCase):
             'date_end': end,
         })
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 4)
+        assert len(pq('li.opinion')) == 4
 
     def test_date_start_valueerror(self):
         # https://bugzilla.mozilla.org/show_bug.cgi?id=898584
@@ -285,29 +284,29 @@ class TestDashboardView(ElasticTestCase):
         r = self.client.get(url, {
             'date_start': '0001-01-01',
         })
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
 
     def test_invalid_search(self):
         url = reverse('dashboard')
         # Invalid values for happy shouldn't filter
         r = self.client.get(url, {'happy': 'fish'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
         # Unknown parameters should be ignored.
         r = self.client.get(url, {'apples': 'oranges'})
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
         # A broken date range search shouldn't affect anything
         # Why this? Because this is the thing the fuzzer found.
         r = self.client.get(url, {
             'date_end': '/etc/shadow\x00',
             'date_start': '/etc/passwd\x00'
         })
-        eq_(r.status_code, 200)
+        assert r.status_code == 200
         pq = PyQuery(r.content)
-        eq_(len(pq('li.opinion')), 7)
+        assert len(pq('li.opinion')) == 7
 
     def test_frontpage_index_missing(self):
         """If index is missing, show es_down template."""
@@ -342,7 +341,7 @@ class TestResponseview(ElasticTestCase):
 
         url = reverse('dashboard')
         r = self.client.get(url)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/dashboard.html')
 
         pq = PyQuery(r.content)
@@ -350,7 +349,7 @@ class TestResponseview(ElasticTestCase):
         permalink = pq('li.opinion a[href*="response"]').attr('href')
 
         r = self.client.get(permalink)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/response.html')
         assert str(resp.description) in r.content
 
@@ -362,7 +361,7 @@ class TestResponseview(ElasticTestCase):
 
         r = self.client.get(reverse('response_view', args=(resp.id,)),
                             {'mobile': 1})
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/mobile/response.html')
         assert str(resp.description) in r.content
 
@@ -373,29 +372,29 @@ class TestResponseview(ElasticTestCase):
         self.refresh()
         r = self.client.get(reverse('response_view', args=(resp.id,)))
 
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/response.html')
         assert str(resp.description) in r.content
 
         # Verify there is no secret area visible for non-analyzers.
         pq = PyQuery(r.content)
         secretarea = pq('dl.secret')
-        eq_(len(secretarea), 0)
+        assert len(secretarea) == 0
 
         jane = AnalyzerProfileFactory(user__email='jane@example.com').user
 
         self.client_login_user(jane)
         r = self.client.get(reverse('response_view', args=(resp.id,)))
 
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
         self.assertTemplateUsed(r, 'analytics/response.html')
         assert str(resp.description) in r.content
 
         # Verify the secret area is there.
         pq = PyQuery(r.content)
         secretarea = pq('dl.secret')
-        eq_(len(secretarea), 1)
+        assert len(secretarea) == 1
 
         # Verify there is an mlt section in the secret area.
         mlt = pq('dd#mlt')
-        eq_(len(mlt), 1)
+        assert len(mlt) == 1


### PR DESCRIPTION
[bug 1193321] Remove eq_ and ok_: analytics
This commit removes eq_ and ok_ imports as well as their use in the
files. It replaces eq_ and ok_ with proper assert statements.