### PR TITLE
Fix pre commit exceptions and update pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: 2d83e302cc2757a28cedc03e6bb075de913c1804
+    sha: cf550fcab3f12015f8676b8278b30e1a5bc10e70 #v0.4.2
     hooks:
     -   id: check-added-large-files
     -   id: check-case-conflict

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,6 +16,9 @@ pep8==1.6.1
 # sha256: Y6KG6ssDzV9kPX60WMbGK3DBEbRjT9jVnyfMrKS3yDo
 django-sslserver==0.14
 
+# If you are updating this, you might want to update
+# the hashes of the hooks repositories listed in the
+# .pre-commit-config.yaml file as well.
 # sha256: jnbbT3Kv6QCHxHRntYjQ3j2_hvbj7nYqok7KqmyhuwM
 pre-commit==0.4.4
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,8 +19,8 @@ django-sslserver==0.14
 # If you are updating this, you might want to update
 # the hashes of the hooks repositories listed in the
 # .pre-commit-config.yaml file as well.
-# sha256: jnbbT3Kv6QCHxHRntYjQ3j2_hvbj7nYqok7KqmyhuwM
-pre-commit==0.4.4
+# sha256: -mMJMMHa-COxV46yDJP5LfCZAEElNKZjdx_wrcJLjg8
+pre-commit==0.5.4
 
 # sha256: qRNwGDrqY8h9hIfns5ntLZmnwvFLEI0nwLyK2e9ZXZo
 aspy.yaml==0.2.1


### PR DESCRIPTION
Update the hash of the pre-commit-hooks repository to that of v0.4.2 which will fix the exceptions caused when running pre-commit hooks. Update pre-commit to the latest version 0.5.4.