### PR TITLE
[bug 1193328] Remove eq_ and ok_: redirector

### DIFF
--- a/fjord/redirector/tests/test_dummy.py
+++ b/fjord/redirector/tests/test_dummy.py
@@ -1,4 +1,4 @@
-from fjord.base.tests import eq_, reverse, TestCase
+from fjord.base.tests import reverse, TestCase
 from fjord.redirector import get_redirectors
 from fjord.redirector.base import build_redirect_url
 from fjord.redirector.providers.dummy import DummyRedirector
@@ -13,7 +13,7 @@ class DummyRedirectorLoadingTestCase(RedirectorTestMixin, TestCase):
             prov for prov in get_redirectors()
             if isinstance(prov, DummyRedirector)
         ]
-        eq_(len(dummy_providers), 0)
+        assert len(dummy_providers) == 0
 
 
 class DummyRedirectorTestCase(RedirectorTestMixin, TestCase):
@@ -26,17 +26,17 @@ class DummyRedirectorTestCase(RedirectorTestMixin, TestCase):
             prov for prov in get_redirectors()
             if isinstance(prov, DummyRedirector)
         ]
-        eq_(len(dummy_redirectors), 1)
+        assert len(dummy_redirectors) == 1
 
     def test_handle_redirect(self):
         resp = self.client.get(build_redirect_url('dummy:ou812'))
-        eq_(resp.status_code, 302)
-        eq_(resp['Location'], 'http://example.com/ou812')
+        assert resp.status_code == 302
+        assert resp['Location'] == 'http://example.com/ou812'
 
     def test_nothing_handled_it_404(self):
         resp = self.client.get(build_redirect_url('notdummy:ou812'))
-        eq_(resp.status_code, 404)
+        assert resp.status_code == 404
 
     def test_no_redirect_specified_404(self):
         resp = self.client.get(reverse('redirect-view'))
-        eq_(resp.status_code, 404)
+        assert resp.status_code == 404


### PR DESCRIPTION
This commit removes eq_ and ok_ imports as well as their use in the
files under redirector directory. It replaces eq_ and ok_ with proper
assert statements.