### PR TITLE
[bug 1193330] Remove eq_ and ok_: search

### DIFF
--- a/fjord/search/tests/test_index.py
+++ b/fjord/search/tests/test_index.py
@@ -1,4 +1,4 @@
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 from fjord.feedback.models import ResponseDocType
 from fjord.feedback.tests import ResponseFactory
 from fjord.search.index import chunked
@@ -8,17 +8,16 @@ from fjord.search.tests import ElasticTestCase
 class ChunkedTests(TestCase):
     def test_chunked(self):
         # chunking nothing yields nothing.
-        eq_(list(chunked([], 1)), [])
+        assert list(chunked([], 1)) == []
 
         # chunking list where len(list) < n
-        eq_(list(chunked([1], 10)), [(1,)])
+        assert list(chunked([1], 10)) == [(1,)]
 
         # chunking a list where len(list) == n
-        eq_(list(chunked([1, 2], 2)), [(1, 2)])
+        assert list(chunked([1, 2], 2)) == [(1, 2)]
 
         # chunking list where len(list) > n
-        eq_(list(chunked([1, 2, 3, 4, 5], 2)),
-            [(1, 2), (3, 4), (5,)])
+        assert list(chunked([1, 2, 3, 4, 5], 2)) == [(1, 2), (3, 4), (5,)]
 
 
 class TestLiveIndexing(ElasticTestCase):
@@ -28,8 +27,8 @@ class TestLiveIndexing(ElasticTestCase):
 
         s = ResponseFactory(happy=True, description='Test live indexing.')
         self.refresh()
-        eq_(count_pre + 1, search.count())
+        assert count_pre + 1 == search.count()
 
         s.delete()
         self.refresh()
-        eq_(count_pre, search.count())
+        assert count_pre == search.count()

--- a/fjord/search/tests/test_models.py
+++ b/fjord/search/tests/test_models.py
@@ -1,4 +1,4 @@
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 from fjord.search.models import Record
 from fjord.search.tests import RecordFactory
 
@@ -8,16 +8,16 @@ class RecordTest(TestCase):
         """Test marking as fail/success."""
         r = RecordFactory()
 
-        eq_(Record.objects.filter(status=Record.STATUS_NEW).count(), 1)
-        eq_(Record.objects.filter(status=Record.STATUS_FAIL).count(), 0)
-        eq_(Record.objects.filter(status=Record.STATUS_SUCCESS).count(), 0)
+        assert Record.objects.filter(status=Record.STATUS_NEW).count() == 1
+        assert Record.objects.filter(status=Record.STATUS_FAIL).count() == 0
+        assert Record.objects.filter(status=Record.STATUS_SUCCESS).count() == 0
 
         r.mark_fail('Errorz!')
-        eq_(Record.objects.filter(status=Record.STATUS_NEW).count(), 0)
-        eq_(Record.objects.filter(status=Record.STATUS_FAIL).count(), 1)
-        eq_(Record.objects.filter(status=Record.STATUS_SUCCESS).count(), 0)
+        assert Record.objects.filter(status=Record.STATUS_NEW).count() == 0
+        assert Record.objects.filter(status=Record.STATUS_FAIL).count() == 1
+        assert Record.objects.filter(status=Record.STATUS_SUCCESS).count() == 0
 
         r.mark_success()
-        eq_(Record.objects.filter(status=Record.STATUS_NEW).count(), 0)
-        eq_(Record.objects.filter(status=Record.STATUS_FAIL).count(), 0)
-        eq_(Record.objects.filter(status=Record.STATUS_SUCCESS).count(), 1)
+        assert Record.objects.filter(status=Record.STATUS_NEW).count() == 0
+        assert Record.objects.filter(status=Record.STATUS_FAIL).count() == 0
+        assert Record.objects.filter(status=Record.STATUS_SUCCESS).count() == 1

--- a/fjord/search/tests/test_tasks.py
+++ b/fjord/search/tests/test_tasks.py
@@ -1,4 +1,3 @@
-from fjord.base.tests import eq_
 from fjord.feedback.models import ResponseDocType
 from fjord.feedback.tests import ResponseFactory
 from fjord.search.index import get_index_name
@@ -18,7 +17,7 @@ class IndexChunkTaskTest(ElasticTestCase):
         self.setup_indexes(empty=True)
 
         # Verify there's nothing in the index.
-        eq_(ResponseDocType.docs.search().count(), 0)
+        assert ResponseDocType.docs.search().count() == 0
 
         # Create the record and the chunk and then run it through
         # celery.
@@ -34,8 +33,8 @@ class IndexChunkTaskTest(ElasticTestCase):
         self.refresh()
 
         # Verify everything is in the index now.
-        eq_(ResponseDocType.docs.search().count(), 10)
+        assert ResponseDocType.docs.search().count() == 10
 
         # Verify the record was marked succeeded.
         rec = Record.objects.get(pk=rec.id)
-        eq_(rec.status, Record.STATUS_SUCCESS)
+        assert rec.status == Record.STATUS_SUCCESS

--- a/fjord/search/tests/test_utils.py
+++ b/fjord/search/tests/test_utils.py
@@ -1,4 +1,3 @@
-from fjord.base.tests import eq_
 from fjord.search.utils import from_class_path, to_class_path
 
 
@@ -7,15 +6,15 @@ class FooBarClassOfAwesome(object):
 
 
 def test_from_class_path():
-    eq_(
+    assert(
         from_class_path(
-            'fjord.search.tests.test_utils:FooBarClassOfAwesome'),
+            'fjord.search.tests.test_utils:FooBarClassOfAwesome') ==
         FooBarClassOfAwesome
     )
 
 
 def test_to_class_path():
-    eq_(
-        to_class_path(FooBarClassOfAwesome),
+    assert(
+        to_class_path(FooBarClassOfAwesome) ==
         'fjord.search.tests.test_utils:FooBarClassOfAwesome'
     )


### PR DESCRIPTION
This commit removes eq_ and ok_ imports as well as their use in the
files under search directory. It replaces eq_ and ok_ with proper
assert statements.