### PR TITLE
[bug 1175123] Fix keyword matching

### DIFF
--- a/fjord/suggest/providers/trigger/models.py
+++ b/fjord/suggest/providers/trigger/models.py
@@ -54,8 +54,8 @@ def _generate_keywords_regex(keywords):
         u'|'.join(keywords) +
         u')'
     )
-    regex = ur'((?:^|\s)' + middle + ur'(?:\s|$))'
-    return re.compile(regex, re.LOCALE | re.IGNORECASE | re.UNICODE)
+    regex = ur'((?:^|\W)' + middle + ur'(?:\W|$))'
+    return re.compile(regex, re.IGNORECASE | re.UNICODE)
 
 
 class TriggerRule(ModelBase):

--- a/fjord/suggest/providers/trigger/models.py
+++ b/fjord/suggest/providers/trigger/models.py
@@ -54,7 +54,9 @@ def _generate_keywords_regex(keywords):
         u'|'.join(keywords) +
         u')'
     )
-    regex = ur'((?:^|\W)' + middle + ur'(?:\W|$))'
+    # Note: Can't use \b here because we need to be able to find
+    # arbitrary strings--not just alphanumeric ones.
+    regex = ur'(?:^|\W)' + middle + ur'(?:\W|$)'
     return re.compile(regex, re.IGNORECASE | re.UNICODE)
 
 

--- a/fjord/suggest/providers/trigger/tests/test_models.py
+++ b/fjord/suggest/providers/trigger/tests/test_models.py
@@ -85,6 +85,7 @@ class TriggerRuleMatchTests(TestCase):
             ([u'my-cat'], u'my-cat has fleas', True),
             ([u'(my cat)'], u'(my cat) has fleas', True),
             ([u'cat'], u'i love my cat!', True),
+            ([u'cat'], u'(cat)', True),
         ]
         for tr_keywords, description, expected in tests:
             tr = TriggerRuleFactory(keywords=tr_keywords)

--- a/fjord/suggest/providers/trigger/tests/test_models.py
+++ b/fjord/suggest/providers/trigger/tests/test_models.py
@@ -84,6 +84,7 @@ class TriggerRuleMatchTests(TestCase):
             ([u'\xca'], u'abcd \xca abcd', True),
             ([u'my-cat'], u'my-cat has fleas', True),
             ([u'(my cat)'], u'(my cat) has fleas', True),
+            ([u'cat'], u'i love my cat!', True),
         ]
         for tr_keywords, description, expected in tests:
             tr = TriggerRuleFactory(keywords=tr_keywords)


### PR DESCRIPTION
Keywords wouldn't match if bounded by a non-alphnum character. e.g.
"best" would not match "firefox is the best!" because the "!" was
neither an end-of-string nor a whitespace character.

This changes the bounds to \W and adds a test.

r?