### PR TITLE
[bug 1193325] Remove eq_ and ok_: feedback.

### DIFF
--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, timedelta
 from django.core.cache import get_cache
 from django.test.client import Client
 
-from fjord.base.tests import eq_, ok_, TestCase, reverse
+from fjord.base.tests import TestCase, reverse
 from fjord.feedback import models
 from fjord.feedback.tests import ResponseFactory
 from fjord.search.tests import ElasticTestCase
@@ -33,8 +33,8 @@ class PublicFeedbackAPITest(ElasticTestCase):
         resp = self.client.get(reverse('feedback-api'))
         # FIXME: test headers
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 3)
-        eq_(len(json_data['results']), 3)
+        assert json_data['count'] == 3
+        assert len(json_data['results']) == 3
 
     def test_id(self):
         feedback = ResponseFactory()
@@ -42,9 +42,9 @@ class PublicFeedbackAPITest(ElasticTestCase):
 
         resp = self.client.get(reverse('feedback-api'), {'id': feedback.id})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 1)
-        eq_(len(json_data['results']), 1)
-        eq_(json_data['results'][0]['id'], feedback.id)
+        assert json_data['count'] == 1
+        assert len(json_data['results']) == 1
+        assert json_data['results'][0]['id'] == feedback.id
 
     def test_multiple_ids(self):
         # Create some responses that we won't ask for
@@ -62,10 +62,10 @@ class PublicFeedbackAPITest(ElasticTestCase):
             {'id': ','.join([str(int(f.id)) for f in resps])}
         )
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 5)
-        eq_(len(json_data['results']), 5)
-        eq_(
-            sorted([item['id'] for item in json_data['results']]),
+        assert json_data['count'] == 5
+        assert len(json_data['results']) == 5
+        assert(
+            sorted([item['id'] for item in json_data['results']]) ==
             sorted([feedback.id for feedback in resps])
         )
 
@@ -79,31 +79,31 @@ class PublicFeedbackAPITest(ElasticTestCase):
             {'id': str(feedback.id) + ',foo'}
         )
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 1)
-        eq_(len(json_data['results']), 1)
-        eq_(json_data['results'][0]['id'], feedback.id)
+        assert json_data['count'] == 1
+        assert len(json_data['results']) == 1
+        assert json_data['results'][0]['id'] == feedback.id
 
     def test_happy(self):
         self.create_basic_data()
 
         resp = self.client.get(reverse('feedback-api'), {'happy': '1'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 2)
-        eq_(len(json_data['results']), 2)
+        assert json_data['count'] == 2
+        assert len(json_data['results']) == 2
 
     def test_platforms(self):
         self.create_basic_data()
 
         resp = self.client.get(reverse('feedback-api'), {'platforms': 'Linux'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 1)
-        eq_(len(json_data['results']), 1)
+        assert json_data['count'] == 1
+        assert len(json_data['results']) == 1
 
         resp = self.client.get(reverse('feedback-api'),
                                {'platforms': 'Linux,Windows'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 2)
-        eq_(len(json_data['results']), 2)
+        assert json_data['count'] == 2
+        assert len(json_data['results']) == 2
 
     def test_products_and_versions(self):
         self.create_basic_data()
@@ -111,42 +111,42 @@ class PublicFeedbackAPITest(ElasticTestCase):
         resp = self.client.get(reverse('feedback-api'),
                                {'products': 'Firefox'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 2)
-        eq_(len(json_data['results']), 2)
+        assert json_data['count'] == 2
+        assert len(json_data['results']) == 2
 
         resp = self.client.get(reverse('feedback-api'),
                                {'products': 'Firefox,Firefox for Android'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 3)
-        eq_(len(json_data['results']), 3)
+        assert json_data['count'] == 3
+        assert len(json_data['results']) == 3
 
         # version without product gets ignored
         resp = self.client.get(reverse('feedback-api'),
                                {'versions': '30.0'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 3)
-        eq_(len(json_data['results']), 3)
+        assert json_data['count'] == 3
+        assert len(json_data['results']) == 3
 
         resp = self.client.get(reverse('feedback-api'),
                                {'products': 'Firefox',
                                 'versions': '30.0'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 1)
-        eq_(len(json_data['results']), 1)
+        assert json_data['count'] == 1
+        assert len(json_data['results']) == 1
 
     def test_locales(self):
         self.create_basic_data()
 
         resp = self.client.get(reverse('feedback-api'), {'locales': 'en-US'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 2)
-        eq_(len(json_data['results']), 2)
+        assert json_data['count'] == 2
+        assert len(json_data['results']) == 2
 
         resp = self.client.get(reverse('feedback-api'),
                                {'locales': 'en-US,de'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 3)
-        eq_(len(json_data['results']), 3)
+        assert json_data['count'] == 3
+        assert len(json_data['results']) == 3
 
     def test_multi_filter(self):
         self.create_basic_data()
@@ -156,16 +156,16 @@ class PublicFeedbackAPITest(ElasticTestCase):
             'locales': 'de', 'happy': 1
         })
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 0)
-        eq_(len(json_data['results']), 0)
+        assert json_data['count'] == 0
+        assert len(json_data['results']) == 0
 
     def test_query(self):
         self.create_basic_data()
 
         resp = self.client.get(reverse('feedback-api'), {'q': 'desc'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 2)
-        eq_(len(json_data['results']), 2)
+        assert json_data['count'] == 2
+        assert len(json_data['results']) == 2
 
     def test_old_responses(self):
         # Make sure we can't see responses from > 180 days ago
@@ -182,7 +182,7 @@ class PublicFeedbackAPITest(ElasticTestCase):
         })
         json_data = json.loads(resp.content)
         results = json_data['results']
-        eq_(len(results), 1)
+        assert len(results) == 1
 
         assert 'Young enough--Party!' in resp.content
         assert 'Too old--Get off my lawn!' not in resp.content
@@ -199,8 +199,9 @@ class PublicFeedbackAPITest(ElasticTestCase):
 
         resp = self.client.get(reverse('feedback-api'))
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 1)
-        eq_(sorted(json_data['results'][0].keys()),
+        assert json_data['count'] == 1
+        assert(
+            sorted(json_data['results'][0].keys()) ==
             sorted(models.ResponseDocType.public_fields()))
 
     def test_max(self):
@@ -210,16 +211,16 @@ class PublicFeedbackAPITest(ElasticTestCase):
 
         resp = self.client.get(reverse('feedback-api'))
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 10)
+        assert json_data['count'] == 10
 
         resp = self.client.get(reverse('feedback-api'), {'max': '5'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 5)
+        assert json_data['count'] == 5
 
         # FIXME: For now, nonsense values get ignored.
         resp = self.client.get(reverse('feedback-api'), {'max': 'foo'})
         json_data = json.loads(resp.content)
-        eq_(json_data['count'], 10)
+        assert json_data['count'] == 10
 
 
 class PublicFeedbackAPIDateTest(ElasticTestCase):
@@ -247,9 +248,9 @@ class PublicFeedbackAPIDateTest(ElasticTestCase):
         resp = self.client.get(reverse('feedback-api'), params)
         json_data = json.loads(resp.content)
         results = json_data['results']
-        eq_(len(json_data['results']), len(expected))
+        assert len(json_data['results']) == len(expected)
         for result, expected in zip(results, expected):
-            eq_(result['created'], expected + 'T00:00:00')
+            assert result['created'] == expected + 'T00:00:00'
 
     def test_date_start(self):
         """date_start returns responses from that day forward"""
@@ -365,27 +366,27 @@ class FeedbackHistogramAPITest(ElasticTestCase):
         self.refresh()
 
         resp = self.client.get(reverse('feedback-histogram-api'))
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         json_data = json.loads(resp.content)
 
         # Default is the last 7 days.
-        eq_(len(json_data['results']), 7)
+        assert len(json_data['results']) == 7
 
         # Last item in the list should be yesterday.
-        eq_(
-            self.to_date_string(json_data['results'][-1][0]),
+        assert(
+            self.to_date_string(json_data['results'][-1][0]) ==
             (today - timedelta(days=1)).strftime('%Y-%m-%d 00:00:00')
         )
         # Count is 2.
-        eq_(json_data['results'][-1][1], 2)
+        assert json_data['results'][-1][1] == 2
 
         # First item is 7 days ago.
-        eq_(
-            self.to_date_string(json_data['results'][0][0]),
+        assert(
+            self.to_date_string(json_data['results'][0][0]) ==
             (today - timedelta(days=7)).strftime('%Y-%m-%d 00:00:00')
         )
         # Count is 2.
-        eq_(json_data['results'][0][1], 2)
+        assert json_data['results'][0][1] == 2
 
     def test_q(self):
         """Test q argument"""
@@ -397,12 +398,12 @@ class FeedbackHistogramAPITest(ElasticTestCase):
         resp = self.client.get(reverse('feedback-histogram-api'), {
             'q': 'pocket'
         })
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         json_data = json.loads(resp.content)
 
         # Default range ends yesterday. Only one response with
         # "pocket" in it yesterday, so this is 1.
-        eq_(json_data['results'][-1][1], 1)
+        assert json_data['results'][-1][1] == 1
 
     # FIXME: Test date_start, date_end and date_delta
     # FIXME: Test products, versions
@@ -429,17 +430,17 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, True)
-        eq_(feedback.description, data['description'])
-        eq_(feedback.product, data['product'])
+        assert feedback.happy == True
+        assert feedback.description == data['description']
+        assert feedback.product == data['product']
 
         # Fills in defaults
-        eq_(feedback.url, u'')
-        eq_(feedback.api, 1)
-        eq_(feedback.user_agent, u'')
+        assert feedback.url == u''
+        assert feedback.api == 1
+        assert feedback.user_agent == u''
 
     def test_maximal(self):
         """Tests an API call with all possible data"""
@@ -479,15 +480,15 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         feedback = models.Response.objects.latest(field_name='id')
         for field in prs.fields.keys():
             if field == 'email':
                 email = models.ResponseEmail.objects.latest(field_name='id')
-                eq_(email.email, data['email'])
+                assert email.email == data['email']
             else:
-                eq_(getattr(feedback, field), data[field])
+                assert getattr(feedback, field) == data[field]
 
     def test_missing_happy_defaults_to_sad(self):
         # We want to require "happy" to be in the values, but for
@@ -505,10 +506,10 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, False)
+        assert feedback.happy == False
 
     def test_whitespace_description_is_invalid(self):
         data = {
@@ -521,7 +522,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
 
     def test_blank_category_is_fine_we_suppose(self):
         data = {
@@ -535,7 +536,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
     def test_invalid_unicode_url(self):
         """Tests an API call with invalid unicode URL"""
@@ -564,10 +565,10 @@ class PostFeedbackAPITest(TestCase):
             content_type='application/json',
             data=json.dumps(data))
 
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
         content = json.loads(r.content)
-        ok_(u'url' in content)
-        ok_(content['url'][0].endswith(u'is not a valid url'))
+        assert u'url' in content
+        assert content['url'][0].endswith(u'is not a valid url')
 
     def test_with_email(self):
         data = {
@@ -585,23 +586,23 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, True)
-        eq_(feedback.description, data['description'])
-        eq_(feedback.platform, data['platform'])
-        eq_(feedback.product, data['product'])
-        eq_(feedback.channel, data['channel'])
-        eq_(feedback.version, data['version'])
+        assert feedback.happy == True
+        assert feedback.description == data['description']
+        assert feedback.platform == data['platform']
+        assert feedback.product == data['product']
+        assert feedback.channel == data['channel']
+        assert feedback.version == data['version']
 
         # Fills in defaults
-        eq_(feedback.url, u'')
-        eq_(feedback.user_agent, u'')
-        eq_(feedback.api, 1)
+        assert feedback.url == u''
+        assert feedback.user_agent == u''
+        assert feedback.api == 1
 
         email = models.ResponseEmail.objects.latest(field_name='id')
-        eq_(email.email, data['email'])
+        assert email.email == data['email']
 
     def test_with_context(self):
         data = {
@@ -620,10 +621,10 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'slopmenow': 'bar'})
+        assert context.data == {'slopmenow': 'bar'}
 
     def test_with_context_truncate_key(self):
         data = {
@@ -642,10 +643,10 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'foo01234567890123456': 'bar'})
+        assert context.data, {'foo01234567890123456': 'bar'}
 
     def test_with_context_truncate_value(self):
         data = {
@@ -664,10 +665,10 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'foo': ('a' * 100)})
+        assert context.data == {'foo': ('a' * 100)}
 
     def test_with_context_20_pairs(self):
         data = {
@@ -688,13 +689,13 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         context = models.ResponseContext.objects.latest(field_name='id')
         data = sorted(context.data.items())
-        eq_(len(data), 20)
-        eq_(data[0], ('foo00', '0'))
-        eq_(data[-1], ('foo19', '19'))
+        assert len(data) == 20
+        assert data[0] == ('foo00', '0')
+        assert data[-1] == ('foo19', '19')
 
     def test_null_device_returns_400(self):
         data = {
@@ -708,7 +709,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
         assert 'device' in r.content
 
     def test_invalid_email_address_returns_400(self):
@@ -727,7 +728,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
         assert 'email' in r.content
 
     def test_missing_description_returns_400(self):
@@ -744,7 +745,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
         assert 'description' in r.content
 
     def test_missing_product_returns_400(self):
@@ -761,7 +762,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
         assert 'product' in r.content
 
     def test_invalid_product_returns_400(self):
@@ -779,7 +780,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
         assert 'product' in r.content
 
     def test_url_max_length(self):
@@ -801,7 +802,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         # 200th character is not fine.
         data = {
@@ -819,7 +820,7 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 400)
+        assert r.status_code == 400
 
     def test_valid_urls(self):
         test_data = [
@@ -854,8 +855,9 @@ class PostFeedbackAPITest(TestCase):
                 reverse('feedback-api'),
                 content_type='application/json',
                 data=json.dumps(data))
-            eq_(r.status_code, 201,
-                msg=('%s != 201 (%s)' % (r.status_code, url)))
+            assert (r.status_code == 201,
+                ('%s != 201 (%s)' % (r.status_code, url))
+                )
 
             get_cache('default').clear()
 
@@ -886,12 +888,12 @@ class PostFeedbackAPITest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.browser, u'Firefox OS')
-        eq_(feedback.browser_version, u'1.0')
-        eq_(feedback.browser_platform, u'Firefox OS')
+        assert feedback.browser == u'Firefox OS'
+        assert feedback.browser_version == u'1.0'
+        assert feedback.browser_platform == u'Firefox OS'
 
 
 class PostFeedbackAPIThrottleTest(TestCase):
@@ -932,14 +934,14 @@ class PostFeedbackAPIThrottleTest(TestCase):
                 reverse('feedback-api'),
                 content_type='application/json',
                 data=json.dumps(data.next()))
-            eq_(r.status_code, 201)
+            assert r.status_code == 201
 
         # This one should trip the throttle trigger
         r = self.client.post(
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data.next()))
-        eq_(r.status_code, 429)
+        assert r.status_code == 429
 
     def test_double_submit_throttle(self):
         # We disallow two submits in a row of the same description
@@ -959,11 +961,11 @@ class PostFeedbackAPIThrottleTest(TestCase):
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 201)
+        assert r.status_code == 201
 
         # Second time and back off!
         r = self.client.post(
             reverse('feedback-api'),
             content_type='application/json',
             data=json.dumps(data))
-        eq_(r.status_code, 429)
+        assert r.status_code == 429

--- a/fjord/feedback/tests/test_models.py
+++ b/fjord/feedback/tests/test_models.py
@@ -1,6 +1,6 @@
 import datetime
 
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 from fjord.feedback.config import TRUNCATE_LENGTH
 from fjord.feedback.models import (
     Product,
@@ -25,23 +25,23 @@ class TestResponseModel(TestCase):
     def test_description_truncate_on_save(self):
         # Extra 10 characters get lopped off on save.
         resp = ResponseFactory(description=('a' * (TRUNCATE_LENGTH + 10)))
-        eq_(resp.description, 'a' * TRUNCATE_LENGTH)
+        assert resp.description == 'a' * TRUNCATE_LENGTH
 
     def test_description_strip_on_save(self):
         # Nix leading and trailing whitespace.
         resp = ResponseFactory(description=u'   \n\tou812\t\n   ')
-        eq_(resp.description, u'ou812')
+        assert resp.description == u'ou812'
 
     def test_url_domain(self):
         # Test a "normal domain"
         resp = ResponseFactory(url=u'http://foo.example.com.br/blah')
-        eq_(resp.url_domain, u'example.com.br')
+        assert resp.url_domain == u'example.com.br'
         assert isinstance(resp.url_domain, unicode)
 
         # Test a unicode domain
         resp = ResponseFactory(
             url=u'http://\u30c9\u30e9\u30af\u30a810.jp/dq10_skillpoint.html')
-        eq_(resp.url_domain, u'\u30c9\u30e9\u30af\u30a810.jp')
+        assert resp.url_domain == u'\u30c9\u30e9\u30af\u30a810.jp'
         assert isinstance(resp.url_domain, unicode)
 
 
@@ -72,7 +72,7 @@ class TestAutoTranslation(TestCase):
 
         # Fetch it from the db again
         resp = Response.objects.get(id=resp.id)
-        eq_(resp.translated_description, u'\xabHOLA\xbb')
+        assert resp.translated_description == u'\xabHOLA\xbb'
 
 
 class TestGenerateTranslationJobs(TestCase):
@@ -98,11 +98,11 @@ class TestGenerateTranslationJobs(TestCase):
         )
 
         # No new jobs should be generated
-        eq_(len(resp.generate_translation_jobs()), 0)
+        assert len(resp.generate_translation_jobs()) == 0
 
         # Re-fetch from the db and make sure the description was copied over
         resp = Response.objects.get(id=resp.id)
-        eq_(resp.description, resp.translated_description)
+        assert resp.description == resp.translated_description
 
     def test_english_gb_no_translation(self):
         """en-GB descriptions should get copied over"""
@@ -113,11 +113,11 @@ class TestGenerateTranslationJobs(TestCase):
         )
 
         # No new jobs should be generated
-        eq_(len(resp.generate_translation_jobs()), 0)
+        assert len(resp.generate_translation_jobs()) == 0
 
         # Re-fetch from the db and make sure the description was copied over
         resp = Response.objects.get(id=resp.id)
-        eq_(resp.description, resp.translated_description)
+        assert resp.description == resp.translated_description
 
     def test_english_with_dennis(self):
         """English descriptions should get copied over"""
@@ -136,11 +136,11 @@ class TestGenerateTranslationJobs(TestCase):
         prod.save()
 
         # No new jobs should be generated
-        eq_(len(resp.generate_translation_jobs()), 0)
+        assert len(resp.generate_translation_jobs()) == 0
 
         # Re-fetch from the db and make sure the description was copied over
         resp = Response.objects.get(id=resp.id)
-        eq_(resp.description, resp.translated_description)
+        assert resp.description == resp.translated_description
 
     def test_spanish_no_translation(self):
         """Spanish should not get translated"""
@@ -152,10 +152,10 @@ class TestGenerateTranslationJobs(TestCase):
         )
 
         # No jobs should be translated
-        eq_(len(resp.generate_translation_jobs()), 0)
+        assert len(resp.generate_translation_jobs()) == 0
 
         # Nothing should be translated
-        eq_(resp.translated_description, u'')
+        assert resp.translated_description == u''
 
     def test_spanish_with_dennis(self):
         """Spanish should get translated"""
@@ -175,12 +175,12 @@ class TestGenerateTranslationJobs(TestCase):
 
         # One job should be generated
         jobs = resp.generate_translation_jobs()
-        eq_(len(jobs), 1)
+        assert len(jobs) == 1
         job = jobs[0]
-        eq_(job[1:], (u'dennis', u'es', u'description',
-                      u'en', 'translated_description'))
+        assert job[1:] == (u'dennis', u'es', u'description',
+                      u'en', 'translated_description')
 
-        eq_(resp.translated_description, u'')
+        assert resp.translated_description == u''
 
     def test_spanish_with_dennis_and_existing_translations(self):
         """Response should pick up existing translation"""
@@ -206,23 +206,23 @@ class TestGenerateTranslationJobs(TestCase):
         prod.save()
 
         # No jobs should be translated
-        eq_(len(resp.generate_translation_jobs()), 0)
-        eq_(resp.translated_description, existing_resp.translated_description)
+        assert len(resp.generate_translation_jobs()) == 0
+        assert resp.translated_description == existing_resp.translated_description
 
 
 class TestComputeGrams(TestCase):
     def test_empty(self):
-        eq_(compute_grams(u''), [])
+        assert compute_grams(u'') == []
 
     def test_parsing(self):
         # stop words are removed
-        eq_(compute_grams(u'i me him her'), [])
+        assert compute_grams(u'i me him her') == []
 
         # capital letters don't matter
-        eq_(compute_grams(u'I ME HIM HER'), [])
+        assert compute_grams(u'I ME HIM HER') == []
 
         # punctuation nixed
-        eq_(compute_grams(u'i, me, him, her'), [])
+        assert compute_grams(u'i, me, him, her') == []
 
     def test_bigrams(self):
         # Note: Tokens look weird after being analyzed probably due to
@@ -231,23 +231,31 @@ class TestComputeGrams(TestCase):
         # futility. Ergo the tests look a little odd. e.g. "youtub"
 
         # One word a bigram does not make
-        eq_(compute_grams(u'youtube'), [])
+        assert compute_grams(u'youtube') == []
 
         # Two words is the minimum number to create a bigram
-        eq_(sorted(compute_grams(u'youtube crash')),
-            ['crash youtube'])
+        assert(
+            sorted(compute_grams(u'youtube crash')) ==
+            ['crash youtube']
+            )
 
         # Three words creates two bigrams
-        eq_(sorted(compute_grams(u'youtube crash flash')),
-            ['crash flash', 'crash youtube'])
+        assert(
+            sorted(compute_grams(u'youtube crash flash')) ==
+            ['crash flash', 'crash youtube']
+            )
 
         # Four words creates three bigrams
-        eq_(sorted(compute_grams(u'youtube crash flash bridge')),
-            ['bridge flash', 'crash flash', 'crash youtube'])
+        assert(
+            sorted(compute_grams(u'youtube crash flash bridge')) ==
+            ['bridge flash', 'crash flash', 'crash youtube']
+            )
 
         # Nix duplicate bigrams
-        eq_(sorted(compute_grams(u'youtube crash youtube flash')),
-            ['crash youtube', 'flash youtube'])
+        assert(
+            sorted(compute_grams(u'youtube crash youtube flash')) ==
+            ['crash youtube', 'flash youtube']
+            )
 
 
 class TestParseData(ElasticTestCase):
@@ -275,15 +283,15 @@ class TestParseData(ElasticTestCase):
         self.setup_indexes()
 
         # Make sure everything is in the db
-        eq_(Response.objects.count(), 15)
-        eq_(ResponseEmail.objects.count(), 5)
-        eq_(ResponseContext.objects.count(), 5)
-        eq_(ResponsePI.objects.count(), 5)
+        assert Response.objects.count() == 15
+        assert ResponseEmail.objects.count() == 5
+        assert ResponseContext.objects.count() == 5
+        assert ResponsePI.objects.count() == 5
 
         # Make sure everything is in the index
         resp_s = ResponseDocType.docs.search()
-        eq_(resp_s.count(), 15)
-        eq_(resp_s.filter('term', has_email=True).count(), 5)
+        assert resp_s.count() == 15
+        assert resp_s.filter('term', has_email=True).count() == 5
 
         # Now purge everything older than 180 days and make sure
         # things got removed that should have gotten removed.
@@ -292,15 +300,15 @@ class TestParseData(ElasticTestCase):
         self.refresh()
 
         # All the Response objects should still be there
-        eq_(Response.objects.count(), 15)
+        assert Response.objects.count() == 15
 
         # For the other objects, 2 should be there for each type
-        eq_(ResponseEmail.objects.count(), 2)
-        eq_(ResponseContext.objects.count(), 2)
-        eq_(ResponsePI.objects.count(), 2)
+        assert ResponseEmail.objects.count() == 2
+        assert ResponseContext.objects.count() == 2
+        assert ResponsePI.objects.count() == 2
 
         # Everything should still be in the index, but the number of
         # things with has_email=True should go down
         resp_s = ResponseDocType.docs.search()
-        eq_(resp_s.count(), 15)
-        eq_(resp_s.filter('term', has_email=True).count(), 2)
+        assert resp_s.count() == 15
+        assert resp_s.filter('term', has_email=True).count() == 2

--- a/fjord/feedback/tests/test_utils.py
+++ b/fjord/feedback/tests/test_utils.py
@@ -1,4 +1,4 @@
-from fjord.base.tests import eq_, TestCase
+from fjord.base.tests import TestCase
 from fjord.feedback.utils import clean_url, compute_grams
 
 
@@ -17,7 +17,7 @@ class Testclean_url(TestCase):
         ]
 
         for url, expected in data:
-            eq_(clean_url(url), expected)
+            assert clean_url(url) == expected
 
 
 class TestComputeGrams(TestCase):
@@ -59,4 +59,4 @@ class TestComputeGrams(TestCase):
         ]
 
         for text, expected in test_data:
-            eq_(sorted(compute_grams(text)), sorted(expected))
+            assert sorted(compute_grams(text)) == sorted(expected)

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -5,7 +5,6 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from fjord.base.tests import (
-    eq_,
     LocalizingClient,
     AnalyzerProfileFactory,
     reverse,
@@ -39,8 +38,8 @@ class TestFeedback(TestCase):
         """
         url = reverse('feedback', args=(u'firefox',))
         resp = self.client.get(url)
-        eq_(resp.status_code, 200)
-        eq_(resp['X-Frame-Options'], 'DENY')
+        assert resp.status_code == 200
+        assert resp['X-Frame-Options'] == 'DENY'
 
     def test_valid_happy(self):
         """Submitting a valid happy form creates an item in the DB.
@@ -57,24 +56,24 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'Firefox rocks!', feedback.description)
-        eq_(u'http://mozilla.org/', feedback.url)
-        eq_(True, feedback.happy)
+        assert u'Firefox rocks!' == feedback.description
+        assert u'http://mozilla.org/' == feedback.url
+        assert True == feedback.happy
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Note: This comes from the user agent from the LocalizingClient
-        eq_(u'Firefox', feedback.product)
-        eq_(u'14.0.1', feedback.version)
+        assert u'Firefox' == feedback.product
+        assert u'14.0.1' == feedback.version
 
         # Make sure it doesn't create an email record
-        eq_(models.ResponseEmail.objects.count(), 0)
+        assert models.ResponseEmail.objects.count() == 0
 
         # Make sure it doesn't create a context record
-        eq_(models.ResponseContext.objects.count(), 0)
+        assert models.ResponseContext.objects.count() == 0
 
     def test_response_id_in_session(self):
         url = reverse('feedback', args=(u'firefox',))
@@ -84,7 +83,7 @@ class TestFeedback(TestCase):
             'url': u'http://mozilla.org/'
         })
         response = models.Response.objects.order_by('-id')[0]
-        eq_(self.client.session['response_id'], response.id)
+        assert self.client.session['response_id'] == response.id
 
     def test_valid_sad(self):
         """Submitting a valid sad form creates an item in the DB.
@@ -100,18 +99,18 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u"Firefox doesn't make me sandwiches. :(", feedback.description)
-        eq_(u'', feedback.url)
-        eq_(False, feedback.happy)
+        assert u"Firefox doesn't make me sandwiches. :(" == feedback.description
+        assert u'' == feedback.url
+        assert False == feedback.happy
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Note: This comes from the user agent from the LocalizingClient
-        eq_(u'Firefox', feedback.product)
-        eq_(u'14.0.1', feedback.version)
+        assert u'Firefox' == feedback.product
+        assert u'14.0.1' == feedback.version
 
     def test_response_id_in_qs_unauthenticated(self):
         """Verify response_id in querystring is ignored if user is not
@@ -121,9 +120,9 @@ class TestFeedback(TestCase):
         url = reverse('thanks') + '?response_id={0}'.format(feedback.id)
         r = self.client.get(url)
 
-        eq_(r.status_code, 200)
-        eq_(r.context['feedback'], None)
-        eq_(r.context['suggestions'], None)
+        assert r.status_code == 200
+        assert r.context['feedback'] == None
+        assert r.context['suggestions'] == None
 
     def test_response_id_in_qs_authenticated(self):
         """Verify response_id in querystring overrides session id"""
@@ -149,9 +148,9 @@ class TestFeedback(TestCase):
         url = reverse('thanks') + '?response_id={0}'.format(feedback.id)
         r = self.client.get(url)
 
-        eq_(r.status_code, 200)
-        eq_(r.context['feedback'].id, feedback.id)
-        eq_(r.context['suggestions'], [])
+        assert r.status_code == 200
+        assert r.context['feedback'].id == feedback.id
+        assert r.context['suggestions'] == []
 
     def test_happy_prefill_in_querystring_is_ignored(self):
         url = reverse('feedback', args=(u'firefox',), locale='en-US')
@@ -161,17 +160,17 @@ class TestFeedback(TestCase):
             'description': u"Firefox is the best browser I've ever used!",
         })
 
-        eq_(resp.status_code, 302)
+        assert resp.status_code == 302
 
         # The url has 0, but the form data is 1, so it should end up as 1.
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, 1)
+        assert feedback.happy == 1
 
         # "happy=0" should be removed from the querystring before
         # figuring out the context. So "foo=bar" should be in the
         # context, but not "happy=0".
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'foo': 'bar'})
+        assert context.data == {'foo': 'bar'}
 
     def test_firefox_os_view(self):
         """Firefox OS returns correct view"""
@@ -213,11 +212,11 @@ class TestFeedback(TestCase):
             })
 
             self.assertRedirects(resp, reverse('thanks'))
-            eq_(count + 1, models.Response.objects.count())
+            assert count + 1 == models.Response.objects.count()
             feedback = models.Response.objects.latest(field_name='id')
-            eq_(u'es', feedback.locale)
-            eq_(u'Firefox', feedback.product)
-            eq_(u'14.0.1', feedback.version)
+            assert u'es' == feedback.locale
+            assert u'Firefox' == feedback.product
+            assert u'14.0.1' == feedback.version
 
         finally:
             # FIXME - We have to do another request to set the
@@ -239,15 +238,15 @@ class TestFeedback(TestCase):
         }
         resp = self.client.post(url, data, HTTP_USER_AGENT=ua)
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Product comes from the url
-        eq_(u'Firefox for Android', feedback.product)
+        assert u'Firefox for Android' == feedback.product
         # Since product in user agent matches url, we set the version,
         # too.
-        eq_(u'24.0', feedback.version)
-        eq_(u'', feedback.channel)
+        assert u'24.0' == feedback.version
+        assert u'' == feedback.channel
 
     def test_urls_product_version(self):
         """Test setting version from the url"""
@@ -261,12 +260,12 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'29', feedback.version)
-        eq_(u'', feedback.channel)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox for Android' == feedback.product
+        assert u'29' == feedback.version
+        assert u'' == feedback.channel
 
     def test_urls_product_version_channel(self):
         """Test setting channel from url"""
@@ -280,12 +279,12 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'29', feedback.version)
-        eq_(u'nightly', feedback.channel)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox for Android' == feedback.product
+        assert u'29' == feedback.version
+        assert u'nightly' == feedback.channel
 
     def test_urls_product_version_uppercased_channel(self):
         """Test setting uppercase channel from the url gets lowercased"""
@@ -299,12 +298,12 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'29', feedback.version)
-        eq_(u'nightly', feedback.channel)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox for Android' == feedback.product
+        assert u'29' == feedback.version
+        assert u'nightly' == feedback.channel
 
     def test_urls_product_version_channel_android_ua(self):
         """Test setting everything with a Fennec user agent"""
@@ -322,12 +321,12 @@ class TestFeedback(TestCase):
             HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'29', feedback.version)
-        eq_(u'nightly', feedback.channel)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox for Android' == feedback.product
+        assert u'29' == feedback.version
+        assert u'nightly' == feedback.channel
 
     def test_urls_product_inferred_platform(self):
         """Test setting product from the url and platform inference"""
@@ -347,11 +346,11 @@ class TestFeedback(TestCase):
             HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox', feedback.product)
-        eq_(u'Windows Vista', feedback.browser_platform)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox' == feedback.product
+        assert u'Windows Vista' == feedback.browser_platform
 
     def test_urls_product_inferred_platform_firefoxdev(self):
         """Test firefoxdev platform gets inferred"""
@@ -371,11 +370,11 @@ class TestFeedback(TestCase):
             HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox dev', feedback.product)
-        eq_(u'Windows Vista', feedback.browser_platform)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox dev' == feedback.product
+        assert u'Windows Vista' == feedback.browser_platform
 
     def test_urls_product_inferred_platform_fxios(self):
         """Test firefoxdev platform gets inferred"""
@@ -433,11 +432,11 @@ class TestFeedback(TestCase):
             HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox dev', feedback.product)
-        eq_(u'', feedback.browser_platform)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox dev' == feedback.product
+        assert u'' == feedback.browser_platform
 
     def test_urls_product_no_inferred_platform(self):
         """Test setting product from the url and platform non-inference"""
@@ -464,11 +463,11 @@ class TestFeedback(TestCase):
             HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Someprod', feedback.product)
-        eq_(u'', feedback.platform)
+        assert u'en-US' == feedback.locale
+        assert u'Someprod' == feedback.product
+        assert u'' == feedback.platform
 
     def test_infer_version_if_product_matches(self):
         """Infer the version from the user agent if products match"""
@@ -486,12 +485,12 @@ class TestFeedback(TestCase):
         resp = self.client.post(url, data, HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1 == models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox', feedback.product)
-        eq_(u'14.0.1', feedback.version)
-        eq_(u'Windows Vista', feedback.platform)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox' == feedback.product
+        assert u'14.0.1' == feedback.version
+        assert u'Windows Vista' == feedback.platform
 
     def test_dont_infer_version_if_product_doesnt_match(self):
         """Don't infer version from the user agent if product doesn't match"""
@@ -509,12 +508,12 @@ class TestFeedback(TestCase):
         resp = self.client.post(url, data, HTTP_USER_AGENT=ua)
 
         self.assertRedirects(resp, reverse('thanks'))
-        eq_(amount + 1, models.Response.objects.count())
+        assert amount + 1, models.Response.objects.count()
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(u'en-US', feedback.locale)
-        eq_(u'Firefox', feedback.product)
-        eq_(u'', feedback.version)
-        eq_(u'', feedback.platform)
+        assert u'en-US' == feedback.locale
+        assert u'Firefox' == feedback.product
+        assert u'' == feedback.version
+        assert u'' == feedback.platform
 
     def test_invalid_form(self):
         """Bad data gets ignored. Thanks!"""
@@ -526,7 +525,7 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 0)
+        assert models.Response.objects.count() == 0
 
     def test_invalid_form_happy(self):
         """Bad data gets ignored. Thanks!"""
@@ -538,7 +537,7 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 0)
+        assert models.Response.objects.count() == 0
 
     def test_invalid_form_sad(self):
         """Bad data gets ignored. Thanks!"""
@@ -550,7 +549,7 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 0)
+        assert models.Response.objects.count() == 0
 
     def test_whitespace_description(self):
         """Descriptions with just whitespace get thrown out"""
@@ -562,7 +561,7 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 0)
+        assert models.Response.objects.count() == 0
 
     def test_unicode_in_description(self):
         """Description should accept unicode data"""
@@ -574,7 +573,7 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 1)
+        assert models.Response.objects.count() == 1
 
     def test_unicode_in_url(self):
         """URL should accept unicode data"""
@@ -586,7 +585,7 @@ class TestFeedback(TestCase):
         })
 
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 1)
+        assert models.Response.objects.count() == 1
 
     def test_valid_urls(self):
         """Test valid url field values"""
@@ -612,7 +611,7 @@ class TestFeedback(TestCase):
 
             self.assertRedirects(r, reverse('thanks'))
             latest = models.Response.objects.latest('pk')
-            eq_(latest.url, expected)
+            assert latest.url == expected
 
     def test_url_cleaning(self):
         """Clean urls before saving"""
@@ -623,7 +622,7 @@ class TestFeedback(TestCase):
             'description': u'foo'
         })
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.url, u'http://mozilla.org/path/')
+        assert feedback.url == u'http://mozilla.org/path/'
 
     def test_url_leading_trailing_whitespace_removal(self):
         """Leading/trailing whitespace in urls is stripped"""
@@ -634,7 +633,7 @@ class TestFeedback(TestCase):
             'description': u'foo'
         })
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.url, u'')
+        assert feedback.url == u''
 
     def test_email_collection(self):
         """If the user enters an email and checks the box, collect email."""
@@ -646,8 +645,8 @@ class TestFeedback(TestCase):
             'email': 'bob@example.com',
             'email_ok': 'on',
         })
-        eq_(models.ResponseEmail.objects.count(), 1)
-        eq_(r.status_code, 302)
+        assert models.ResponseEmail.objects.count() == 1
+        assert r.status_code == 302
 
     def test_email_privacy(self):
         """If an email is entered, but box is not checked, don't collect."""
@@ -661,8 +660,8 @@ class TestFeedback(TestCase):
             'email': 'bob@example.com',
             'email_ok': '',
         })
-        eq_(email_count, models.ResponseEmail.objects.count())
-        eq_(r.status_code, 302)
+        assert email_count == models.ResponseEmail.objects.count()
+        assert r.status_code == 302
 
     def test_email_missing(self):
         """If no email, ignore it."""
@@ -673,10 +672,10 @@ class TestFeedback(TestCase):
             'description': u'Can you fix it?',
             'email_ok': 'on',
         })
-        eq_(models.Response.objects.count(), 1)
-        eq_(models.ResponseEmail.objects.count(), 0)
+        assert models.Response.objects.count() == 1
+        assert models.ResponseEmail.objects.count() == 0
         assert not models.ResponseEmail.objects.exists()
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
 
     def test_email_invalid(self):
         """If email_ok box is checked, but bad email or no email, ignore it."""
@@ -691,7 +690,7 @@ class TestFeedback(TestCase):
             'email': '/dev/sda1\0',
         })
         assert not models.ResponseEmail.objects.exists()
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
 
         # Invalid email address is ignored if email_ok box is not
         # checked.
@@ -703,7 +702,7 @@ class TestFeedback(TestCase):
         })
         assert not models.ResponseEmail.objects.exists()
         # Bad email if the box is not checked is not an error.
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
 
     def test_browser_data_collection(self):
         """If the user checks the box, collect the browser data."""
@@ -716,10 +715,10 @@ class TestFeedback(TestCase):
             'browser_ok': 'on',
             'browser_data': json.dumps(browser_data)
         })
-        eq_(r.status_code, 302)
-        eq_(models.ResponsePI.objects.count(), 1)
+        assert r.status_code == 302
+        assert models.ResponsePI.objects.count() == 1
         rti = models.ResponsePI.objects.latest('id')
-        eq_(rti.data, browser_data)
+        assert rti.data == browser_data
 
     def test_browser_data_not_ok(self):
         """If the user doesn't check the box, don't collect data."""
@@ -736,8 +735,8 @@ class TestFeedback(TestCase):
             'browser_ok': '',
             'browser_data': json.dumps(browser_data)
         })
-        eq_(r.status_code, 302)
-        eq_(models.ResponsePI.objects.count(), 0)
+        assert r.status_code == 302
+        assert models.ResponsePI.objects.count() == 0
 
     def test_browser_data_invalid(self):
         """If browser_data is not valid json, don't collect it."""
@@ -749,8 +748,8 @@ class TestFeedback(TestCase):
             'browser_ok': 'on',
             'browser_data': 'invalid json'
         })
-        eq_(r.status_code, 302)
-        eq_(models.ResponsePI.objects.count(), 0)
+        assert r.status_code == 302
+        assert models.ResponsePI.objects.count() == 0
 
     def test_browser_data_there_for_product_as_firefox(self):
         # Feedback for ProductFoo should collect browser data if the browser
@@ -817,7 +816,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.source, u'newsletter')
+        assert feedback.source == u'newsletter'
 
     def test_utm_source_to_source(self):
         """We capture the utm_source querystring arg in the source column"""
@@ -831,7 +830,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.source, u'newsletter')
+        assert feedback.source == u'newsletter'
 
     def test_utm_campaign_to_source(self):
         """We capture the utm_campaign querystring arg in the source column"""
@@ -845,7 +844,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.campaign, u'20140220_email')
+        assert feedback.campaign == u'20140220_email'
 
     def test_save_context_basic(self):
         """We capture any querystring vars as context"""
@@ -859,7 +858,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'foo': 'bar'})
+        assert context.data == {'foo': 'bar'}
 
     def test_save_context_long_key(self):
         """Long keys are truncated"""
@@ -873,7 +872,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'foo12345678901234567': 'bar'})
+        assert context.data == {'foo12345678901234567': 'bar'}
 
     def test_save_context_long_val(self):
         """Long values are truncated"""
@@ -887,7 +886,7 @@ class TestFeedback(TestCase):
         self.assertRedirects(r, reverse('thanks'))
 
         context = models.ResponseContext.objects.latest(field_name='id')
-        eq_(context.data, {'foo': ('a' * 100)})
+        assert context.data == {'foo': ('a' * 100)}
 
     def test_save_context_maximum_pairs(self):
         """Only save 20 pairs"""
@@ -904,9 +903,9 @@ class TestFeedback(TestCase):
 
         context = models.ResponseContext.objects.latest(field_name='id')
         data = sorted(context.data.items())
-        eq_(len(data), 20)
-        eq_(data[0], (u'foo00', '0'))
-        eq_(data[-1], (u'foo19', '19'))
+        assert len(data) == 20
+        assert data[0] == (u'foo00', '0')
+        assert data[-1] == (u'foo19', '19')
 
 
 class TestDeprecatedAndroidFeedback(TestCase):
@@ -926,19 +925,19 @@ class TestDeprecatedAndroidFeedback(TestCase):
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
         r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, True)
-        eq_(feedback.url, data['url'])
-        eq_(feedback.description, data['description'])
-        eq_(feedback.device, data['device'])
-        eq_(feedback.manufacturer, data['manufacturer'])
+        assert feedback.happy == True
+        assert feedback.url == data['url']
+        assert feedback.description == data['description']
+        assert feedback.device == data['device']
+        assert feedback.manufacturer == data['manufacturer']
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Note: This comes from the user agent from the LocalizingClient
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'24.0', feedback.version)
+        assert u'Firefox for Android' == feedback.product
+        assert u'24.0' == feedback.version
 
     def test_deprecated_firefox_for_android_sad_is_sad(self):
         data = {
@@ -953,17 +952,17 @@ class TestDeprecatedAndroidFeedback(TestCase):
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
         r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, False)
-        eq_(feedback.url, data['url'])
-        eq_(feedback.description, data['description'])
+        assert feedback.happy == False
+        assert feedback.url == data['url']
+        assert feedback.description == data['description']
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Note: This comes from the user agent from the LocalizingClient
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'24.0', feedback.version)
+        assert u'Firefox for Android' == feedback.product
+        assert u'24.0' == feedback.version
 
     def test_deprecated_firefox_for_android_ideas_are_sad(self):
         """We treat "sad" and "ideas" as sad feedback now."""
@@ -979,17 +978,17 @@ class TestDeprecatedAndroidFeedback(TestCase):
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
         r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, False)
-        eq_(feedback.url, data['url'])
-        eq_(feedback.description, data['description'])
+        assert feedback.happy == False
+        assert feedback.url == data['url']
+        assert feedback.description == data['description']
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Note: This comes from the user agent from the LocalizingClient
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'24.0', feedback.version)
+        assert u'Firefox for Android' == feedback.product
+        assert u'24.0' == feedback.version
 
     def test_deprecated_firefox_for_android_minimal(self):
         """Test the minimal post data from FfA works."""
@@ -1003,17 +1002,17 @@ class TestDeprecatedAndroidFeedback(TestCase):
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
         r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.happy, True)
-        eq_(feedback.url, u'')
-        eq_(feedback.description, data['description'])
+        assert feedback.happy == True
+        assert feedback.url == u''
+        assert feedback.description == data['description']
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale)
+        assert u'en-US' == feedback.locale
         # Note: This comes from the user agent from the LocalizingClient
-        eq_(u'Firefox for Android', feedback.product)
-        eq_(u'24.0', feedback.version)
+        assert u'Firefox for Android' == feedback.product
+        assert u'24.0' == feedback.version
 
     def test_deprecated_firefox_for_android_phony_ua(self):
         """Test that phony user agents works. bug 855671."""
@@ -1030,18 +1029,18 @@ class TestDeprecatedAndroidFeedback(TestCase):
 
         r = self.client.post(reverse('feedback'), data,
                              HTTP_USER_AGENT=ua)
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
-        eq_(feedback.browser, u'')
-        eq_(feedback.browser_version, u'')
-        eq_(feedback.platform, u'')
+        assert feedback.browser == u''
+        assert feedback.browser_version == u''
+        assert feedback.platform == u''
 
         # This comes from the client.post url.
-        eq_(u'en-US', feedback.locale, u'en-US')
+        assert ( u'en-US' == feedback.locale, u'en-US')
         # This comes from the user agent from the LocalizingClient
-        eq_(feedback.product, u'')
-        eq_(feedback.channel, u'')
-        eq_(feedback.version, u'')
+        assert feedback.product == u''
+        assert feedback.channel == u''
+        assert feedback.version == u''
 
 
 class TestPicker(TestCase):
@@ -1055,7 +1054,7 @@ class TestPicker(TestCase):
     def test_picker_no_products(self):
         resp = self.client.get(reverse('feedback'))
 
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
         self.assertTemplateUsed(resp, 'feedback/picker.html')
         assert 'No products available.' in resp.content
 
@@ -1067,7 +1066,7 @@ class TestPicker(TestCase):
 
         resp = self.client.get(reverse('feedback'))
 
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
 
         self.assertContains(resp, 'ProductFoo')
         self.assertContains(resp, 'productfoo')
@@ -1084,7 +1083,7 @@ class TestPicker(TestCase):
 
         resp = self.client.get(reverse('feedback'))
 
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
 
         # This is on the picker
         self.assertContains(resp, 'ProductFoo')
@@ -1104,7 +1103,7 @@ class TestPicker(TestCase):
 
         resp = self.client.get(reverse('feedback'))
 
-        eq_(resp.status_code, 200)
+        assert resp.status_code == 200
 
         # This is on the picker
         self.assertContains(resp, 'ProductFoo')
@@ -1130,7 +1129,7 @@ class TestCSRF(TestCase):
             'url': u'http://mozilla.org/'
         })
 
-        eq_(r.status_code, 403)
+        assert r.status_code == 403
 
     def test_firefox_for_android(self):
         """No csrf token for a FfA post works fine."""
@@ -1141,7 +1140,7 @@ class TestCSRF(TestCase):
             'add_url': 1,
             'url': u'http://mozilla.org/'
         })
-        eq_(r.status_code, 302)
+        assert r.status_code == 302
 
 
 class TestWebFormThrottling(TestCase):
@@ -1152,7 +1151,7 @@ class TestWebFormThrottling(TestCase):
         # Make sure there are no responses in the db because we're
         # basing our test on response counts.
         initial_amount = models.Response.objects.count()
-        eq_(initial_amount, 0)
+        assert initial_amount == 0
 
         url = reverse('feedback', args=(u'firefox',))
 
@@ -1163,7 +1162,7 @@ class TestWebFormThrottling(TestCase):
                 'description': u'{0} Firefox rocks! {0}'.format(i),
                 'url': u'http://mozilla.org/'
             })
-        eq_(models.Response.objects.count(), 50)
+        assert models.Response.objects.count() == 50
 
         # The 101st should be throttled, so there should only be 100
         # responses in the db.
@@ -1172,7 +1171,7 @@ class TestWebFormThrottling(TestCase):
             'description': u'Firefox rocks!',
             'url': u'http://mozilla.org/'
         })
-        eq_(models.Response.objects.count(), 50)
+        assert models.Response.objects.count() == 50
 
         # Make sure we still went to the Thanks page.
         self.assertRedirects(r, reverse('thanks'))
@@ -1182,7 +1181,7 @@ class TestWebFormThrottling(TestCase):
         # Make sure there are no responses in the db because we're
         # basing our test on response counts.
         initial_amount = models.Response.objects.count()
-        eq_(initial_amount, 0)
+        assert initial_amount == 0
 
         url = reverse('feedback', args=(u'firefox',))
 
@@ -1195,15 +1194,15 @@ class TestWebFormThrottling(TestCase):
         # Post it!
         r = self.client.post(url, data)
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 1)
+        assert models.Response.objects.count() == 1
 
         # Post it again! This time it doesn't get to the db.
         r = self.client.post(url, data)
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 1)
+        assert models.Response.objects.count() == 1
 
         # Post something different from the same ip address.
         data['description'] = u'Not a double-submit!'
         r = self.client.post(url, data)
         self.assertRedirects(r, reverse('thanks'))
-        eq_(models.Response.objects.count(), 2)
+        assert models.Response.objects.count() == 2


### PR DESCRIPTION
This commit removes eq_ and ok_ imports as well as their use in the
files under feedback directory. It replaces eq_ and ok_ with proper
assert statements.