### PR TITLE
[bug 1032951] Upgrade lxml to 3.4.4

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -9,5 +9,5 @@ Jinja2==2.5.5
 # sha256: rxL5lFTolenkMMdXI8O5QZwLzNDqd4A2YtaprFb2Qls
 py-bcrypt==0.3
 
-# sha256: CRLV6D2egvLG7hJny1zvsP_82eILGbvB5S4mYu8w4GQ
-lxml==2.3.5
+# sha256: s9NiusRxFydHzaNRMjjxFcvWxfi45jGb9ql6eJJyQJk
+lxml==3.4.4


### PR DESCRIPTION
This only affects local development environments and doesn't affect server environments.

I have a bug open with webops to figure out the server environments side.

The only two things that seem to use lxml are pyquery (which we use in the tests) and translate-toolkit (which we use extracting strings). I don't see evidence of other things using lxml. It's entirely possible that nothing of substance uses it at all.

Given that, I figured I might as well make a PR for it.

r?