### PR TITLE
[bug 1203118] Upgrade djangorestframework 3.1.3 -> 3.2.3

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -111,8 +111,8 @@ django-ratelimit==0.4.0
 # sha256: wOkPMEu_bxD2PgAZECmAyVDcaDMm0qTlDnGZ3sxDw2o
 django-statsd-mozilla==0.3.15
 
-# sha256: YPJ9jdB0c4sT7ZJqy7C9UbTnFn05Q6BFZkVxGuIrGrQ
-djangorestframework==3.1.3
+# sha256: Qdq1cn7hrrPVsooSatDSj7-A-DI4LNqj8HgRPx4kdxo
+djangorestframework==3.2.3
 
 # sha256: 4o-THuB1Rpz5wPzTUfeAHqCqbXiNAc2-g54qs1a4yjY
 eadred==0.3


### PR DESCRIPTION
No code changes required. I don't think our DRF code uses anything that
changed between versions.