### PR TITLE
Cosmetic: Change relative imports to absolute imports

### DIFF
--- a/fjord/__init__.py
+++ b/fjord/__init__.py
@@ -13,6 +13,7 @@ _has_setup_vendor_path = False
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+
 def path(*a):
     return os.path.join(ROOT, *a)
 
@@ -58,4 +59,4 @@ setup_vendor_path()
 # Setup celery
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery import app as celery_app
+from fjord.celery import app as celery_app  # noqa

--- a/fjord/alerts/tests/test_api.py
+++ b/fjord/alerts/tests/test_api.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 
 from django.test.utils import override_settings
 
-from . import AlertFlavorFactory, AlertFactory, LinkFactory
 from fjord.alerts.models import Alert, Link
+from fjord.alerts.tests import AlertFlavorFactory, AlertFactory, LinkFactory
 from fjord.api_auth.tests import TokenFactory
 from fjord.base.tests import reverse, TestCase, WHATEVER
 

--- a/fjord/base/admin.py
+++ b/fjord/base/admin.py
@@ -11,7 +11,7 @@ from django.views import debug
 
 from celery import current_app
 
-from .tasks import celery_health_task
+from fjord.base.tasks import celery_health_task
 
 
 def timezone_view(request):

--- a/fjord/events/urls.py
+++ b/fjord/events/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from .views import EventAPI
+from fjord.events.views import EventAPI
 
 
 urlpatterns = patterns(

--- a/fjord/events/views.py
+++ b/fjord/events/views.py
@@ -1,8 +1,8 @@
 import rest_framework.views
 import rest_framework.response
 
-from .models import get_product_details_history
 from fjord.base.utils import smart_str
+from fjord.events.models import get_product_details_history
 
 
 class EventAPI(rest_framework.views.APIView):

--- a/fjord/heartbeat/admin.py
+++ b/fjord/heartbeat/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Survey
+from fjord.heartbeat.models import Survey
 
 
 class SurveyAdmin(admin.ModelAdmin):

--- a/fjord/heartbeat/api_views.py
+++ b/fjord/heartbeat/api_views.py
@@ -4,8 +4,8 @@ import rest_framework.views
 import rest_framework.response
 from statsd.defaults.django import statsd
 
-from .models import Answer, AnswerSerializer
 from fjord.base.utils import cors_enabled
+from fjord.heartbeat.models import Answer, AnswerSerializer
 from fjord.journal.utils import j_error
 
 

--- a/fjord/heartbeat/tests/test_api.py
+++ b/fjord/heartbeat/tests/test_api.py
@@ -1,9 +1,9 @@
 import json
 import time
 
-from . import SurveyFactory
-from ..models import Answer
 from fjord.base.tests import TestCase, reverse
+from fjord.heartbeat.models import Answer
+from fjord.heartbeat.tests import SurveyFactory
 from fjord.journal.models import Record
 
 
@@ -152,7 +152,7 @@ class HeartbeatPostAPITest(TestCase):
 
             assert getattr(ans, field) == data[field]
 
-        assert ans.is_test == False
+        assert ans.is_test is False
 
     def test_country_unknown(self):
         """This is a stopgap fix for handling 'unknown' value for country"""
@@ -318,15 +318,15 @@ class HeartbeatPostAPITest(TestCase):
         # Make sure the answer made it to the db and that the data
         # matches.
         ans = Answer.objects.latest('id')
-        assert ans.person_id ==  data['person_id']
+        assert ans.person_id == data['person_id']
         assert ans.survey_id.name == data['survey_id']
-        assert ans.flow_id ==  data['flow_id']
-        assert ans.question_id ==  data['question_id']
-        assert ans.updated_ts ==  data['updated_ts']
-        assert ans.question_text ==  data['question_text']
-        assert ans.variation_id ==  data['variation_id']
-        assert ans.score ==  None
-        assert ans.max_score == None
+        assert ans.flow_id == data['flow_id']
+        assert ans.question_id == data['question_id']
+        assert ans.updated_ts == data['updated_ts']
+        assert ans.question_text == data['question_text']
+        assert ans.variation_id == data['variation_id']
+        assert ans.score is None
+        assert ans.max_score is None
 
         ans_id = ans.id
 
@@ -420,7 +420,7 @@ class HeartbeatPostAPITest(TestCase):
             reverse('heartbeat-api'),
             HTTP_ACCESS_CONTROL_REQUEST_METHOD='',
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS='')
-        assert resp['Access-Control-Allow-Methods'] =='POST'
+        assert resp['Access-Control-Allow-Methods'] == 'POST'
         assert resp['Access-Control-Allow-Origin'] == '*'
 
     # FIXME: test bad types and validation so we can suss out

--- a/fjord/journal/admin.py
+++ b/fjord/journal/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Record
+from fjord.journal.models import Record
 
 
 class RecordAdmin(admin.ModelAdmin):

--- a/fjord/journal/utils.py
+++ b/fjord/journal/utils.py
@@ -1,4 +1,4 @@
-from .models import Record, RECORD_INFO, RECORD_ERROR
+from fjord.journal.models import Record, RECORD_INFO, RECORD_ERROR
 
 
 def j_info(app, src, action, msg, instance=None, metadata=None):

--- a/fjord/redirector/__init__.py
+++ b/fjord/redirector/__init__.py
@@ -18,4 +18,6 @@ def get_redirectors():
     return list(_REDIRECTORS)
 
 
-from .base import build_redirect_url, Redirector, RedirectParseError
+from fjord.redirector.base import (
+    build_redirect_url, Redirector, RedirectParseError
+)

--- a/fjord/suggest/__init__.py
+++ b/fjord/suggest/__init__.py
@@ -12,4 +12,4 @@ def get_suggesters():
     return list(_SUGGESTERS)
 
 
-from .base import Link, Suggester
+from fjord.suggest.base import Link, Suggester

--- a/fjord/translations/admin.py
+++ b/fjord/translations/admin.py
@@ -6,13 +6,13 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.module_loading import import_by_path
 
-from .gengo_utils import FjordGengo
-from .models import GengoJob, GengoOrder
-from .tasks import translate_tasks_by_id_list
-from .utils import locale_equals_language
 from fjord.base.utils import smart_date, smart_str
 from fjord.feedback.models import Product
 from fjord.journal.models import Record
+from fjord.translations.gengo_utils import FjordGengo
+from fjord.translations.models import GengoJob, GengoOrder
+from fjord.translations.tasks import translate_tasks_by_id_list
+from fjord.translations.utils import locale_equals_language
 
 
 class GengoJobAdmin(admin.ModelAdmin):

--- a/fjord/translations/models.py
+++ b/fjord/translations/models.py
@@ -10,18 +10,18 @@ from dennis.translator import Translator
 from statsd.defaults.django import statsd
 import waffle
 
-from .gengo_utils import (
+from fjord.base.models import ModelBase
+from fjord.base.utils import instance_to_key, wrap_with_paragraphs
+from fjord.journal.models import Record
+from fjord.journal.utils import j_error, j_info
+from fjord.translations.gengo_utils import (
     GengoError,
     FjordGengo,
     GengoUnknownLanguage,
     GengoUnsupportedLanguage,
     GENGO_UNSUPPORTED_MACHINE_LC_SRC
 )
-from .utils import locale_equals_language
-from fjord.base.models import ModelBase
-from fjord.base.utils import instance_to_key, wrap_with_paragraphs
-from fjord.journal.models import Record
-from fjord.journal.utils import j_error, j_info
+from fjord.translations.utils import locale_equals_language
 
 
 class SuperModel(models.Model):

--- a/fjord/translations/tasks.py
+++ b/fjord/translations/tasks.py
@@ -3,7 +3,7 @@ from django.utils.module_loading import import_by_path
 
 from fjord.base.utils import key_to_instance
 from fjord.celery import app
-from .utils import translate
+from fjord.translations.utils import translate
 
 
 @app.task(rate_limit='60/m')

--- a/fjord/translations/tests/test_tasks.py
+++ b/fjord/translations/tests/test_tasks.py
@@ -1,6 +1,6 @@
-from ..models import SuperModel
-from ..tasks import translate_tasks_by_id_list
 from fjord.base.tests import TestCase
+from fjord.translations.models import SuperModel
+from fjord.translations.tasks import translate_tasks_by_id_list
 
 
 class TranslateTasksByIdListTestCase(TestCase):

--- a/fjord/translations/tests/test_utils.py
+++ b/fjord/translations/tests/test_utils.py
@@ -1,7 +1,7 @@
-from ..utils import translate
 from fjord.base.tests import TestCase
 from fjord.translations import gengo_utils
 from fjord.translations.models import SuperModel
+from fjord.translations.utils import translate
 
 
 class GeneralTranslateTests(TestCase):

--- a/fjord/translations/utils.py
+++ b/fjord/translations/utils.py
@@ -1,4 +1,4 @@
-from .exceptions import NoSuchSystem
+from fjord.translations.exceptions import NoSuchSystem
 
 
 def translate(instance, system, src_lang, src_field, dst_lang, dst_field):
@@ -19,7 +19,7 @@ def translate(instance, system, src_lang, src_field, dst_lang, dst_field):
 
     """
     # Have to import this here because of circular import problems.
-    from .models import get_translation_systems
+    from fjord.translations.models import get_translation_systems
 
     # Get the translation system class.
     TranslationSystem = get_translation_systems().get(system)

--- a/fjord/translations/views.py
+++ b/fjord/translations/views.py
@@ -1,1 +1,0 @@
-# Create your views here.


### PR DESCRIPTION
Most of the code base uses absolute imports, but we used relative imports in a few places. The case for using relative imports is that it theoretically makes it easier to pluck the code and stick it somewhere else. Sure, but there's no way we're moving this code somewhere else, so I'd rather the imports were clearer and more explicit.

Given that, I changed all the relative imports to absolute imports.

Minor r?