### PR TITLE
[bug 1202647] Update dev requirements

### DIFF
--- a/py.test
+++ b/py.test
@@ -26,5 +26,5 @@ if __name__ == '__main__':
     USING_VENDOR = os.environ.get('USING_VENDOR', '0')
 
     sys.exit(
-        load_entry_point('pytest==2.7.1', 'console_scripts', 'py.test')()
+        load_entry_point('pytest==2.7.2', 'console_scripts', 'py.test')()
     )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,59 +1,49 @@
 # These requirements are helpful, but not required, for working on fjord
-
-# sha256: KF6L1zDAtv374jwy0pNr_7pAHyPKsTLocixovoDW8YI
-flake8==2.2.5
-
-# sha256: PYypv2XFAU9GkYBUTR3Vu1ud9wmq1jBPnC5DcK4Ke3w
-mccabe==0.3
-
-# sha256: P6gKELNtUWhr93RPXcmWIs1cmM6O1kAi5imGiq_Bd2k
-pyflakes==0.8.1
-
-# sha256: VzZ3y4X_CJJEsPma-VX3bC43RWYyYQtt7aYWcTnOFVo
-pep8==1.6.1
-
 # For testing remote-troubleshooting capture.
-# sha256: Y6KG6ssDzV9kPX60WMbGK3DBEbRjT9jVnyfMrKS3yDo
-django-sslserver==0.14
+# sha256: DcQq0cP8Yttg6S5O-HnzrvTco61_o146MoZukfNbGwM
+django-sslserver==0.15
 
 # If you are updating this, you might want to update
 # the hashes of the hooks repositories listed in the
 # .pre-commit-config.yaml file as well.
-# sha256: -mMJMMHa-COxV46yDJP5LfCZAEElNKZjdx_wrcJLjg8
-pre-commit==0.5.4
+# sha256: AnUshRna3Tz1V6c2KD9KB3LF72xU6XwRPs3_1mtnrKw
+pre-commit==0.5.5
 
 # sha256: qRNwGDrqY8h9hIfns5ntLZmnwvFLEI0nwLyK2e9ZXZo
 aspy.yaml==0.2.1
 
-# sha256: 6gYn4M8e_0ZftBZrbt3sQW4dq48w1kucWz_6uJgHJmE
-cached-property==1.1.0
+# sha256: 4wgagYLT1LcoPuredsOCvP1N_WRMqABZginC73mKu1M
+cached-property==1.2.0
 
-# sha256: Epii8bL0xKe5IczNFZ5OQvbXsPt1yGwM3s_HHwYYM_o
-jsonschema==2.4.0
+# sha256: Nmc6w3j-7T2qWVYnaoKWmQVlI9eWECeRHwZLUiVerUE
+jsonschema==2.5.1
 
-# sha256: z-plZ1KzlnhB98MAocl1ZSYBPuGfOsR9srdxNP84tQk
-nodeenv==0.13.1
+# sha256: 4teASdw41L4gVS3AO3AVbYCUBQfcnCAcdvLWEasfbZU
+nodeenv==0.13.5
 
 # sha256: w2yTiocuX_SUk4szsUqqFWy0OexnVI_Ks1Nbt4sIRug
 pyyaml==3.11
 
-# sha256: PIjPffEUwyzwZR0S-Xm421VtmS1kdJPlvbvigovkAAc
-virtualenv==12.1.1
+# sha256: qryO8YzdvYoqnH-SvEPi_qVLEUczDWXbkg7zzpgS49w
+virtualenv==13.1.2
 
-# sha256: PkWmgeXnnrMfCUsxhDNG7Zo95Of2682hDHSLPEXFWX4
-simplejson==3.0.7
+# sha256: IX5Hl9o6mkqfvmci4NuYBwuEQ6iCEtes29JBp2aBQdk
+simplejson==3.8.0
 
 # sha256: HDW0rCBs7y0kgWyJ-Jzyid09OM98RJuz-re_bUPwGx8
 ordereddict==1.1
 
-# sha256: KN0LkNKbOGr7VS78TjVciJ9GOc6TZYp4cqIVDs4ou4k
-py==1.4.26
+# sha256: twPldoXtfCgLGlHElqSYTYPYne8qkwtenl2lpsoVFRQ
+py==1.4.30
 
-# sha256: Uw8jx54bE4UOk_OllyDx7KdbrQEwfcT9aUpqGWGfucs
-pytest==2.7.1
+# sha256: swRX9zVCDQAA0QpEu9R4zwP4vyDiW9dySPm6tA9P1qQ
+pytest==2.7.2
 
 # sha256: 0UWsncelV6cZq3l3C-CUEATh4DjhN8NFkZGdnfKnkLE
 pytest-django==2.8.0
 
 # sha256: Gm5RMMK0LS3jAWk8KZ94zEvTUB54thDAjkXvxw4rURQ
 Sphinx==1.3.1
+
+# sha256: 9iU9--BTitLjh72P39kpPJJdY1U_WBPE5Yd0VBZQHm0
+functools32==3.2.3-2


### PR DESCRIPTION
Update the dependencies listed in the bug 1202647.
Get rid of flake8 and its dependencies since we no longer use it
directly. pre-commit installs flake8 from its dependencies in its
own virtualenv and does not use the one we have been installing till
now.