### PR TITLE
[bug 1146686] Remove django-cronjobs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,9 +34,6 @@
 [submodule "vendor/src/commonware"]
 	path = vendor/src/commonware
 	url = git://github.com/jsocol/commonware.git
-[submodule "vendor/src/django-cronjobs"]
-	path = vendor/src/django-cronjobs
-	url = git://github.com/jsocol/django-cronjobs.git
 [submodule "vendor/src/django-mobility"]
 	path = vendor/src/django-mobility
 	url = git://github.com/jbalogh/django-mobility.git

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -232,7 +232,6 @@ LANGUAGES = lazy(lazy_langs, dict)()
 
 INSTALLED_APPS = (
     # Local apps
-    'cronjobs',  # for ./manage.py cron * cmd line tasks
     'django_browserid',
 
     # Django contrib apps

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -84,9 +84,6 @@ django-adminplus==0.3
 # sha256: -jPrQhcqGbcVrbp6ZJcJEftdj9G2nPjaepXyvH8PMDs
 django-browserid==1.0
 
-# sha256: F3KVsUQkAMks22fo4Y-f9ZRvtEL4WBO50IN4I3IuoI0
-django-cronjobs==0.2.3
-
 # sha256: ZfstcU_VvbmwiDKZPCyEeLJdmMKj54dpbP52KsrmRUQ
 django-extensions==1.5.6
 

--- a/vendor/vendor.pth
+++ b/vendor/vendor.pth
@@ -30,7 +30,6 @@ src/babel
 src/dateutil
 src/django-browserid
 src/django_compressor
-src/django-cronjobs
 src/django-eadred
 src/django-extensions
 src/django-grappelli


### PR DESCRIPTION
Input doesn't use django-cronjobs. This removes it from the requirements
and vendor/.