### PR TITLE
[bug 1209787] Fix tests sending GA data

### DIFF
--- a/fjord/base/google_utils.py
+++ b/fjord/base/google_utils.py
@@ -31,6 +31,9 @@ def ga_track_event(params, async=True):
        testing/development data hosing your production data.
 
     """
+    if sys.argv and sys.argv[0].endswith('py.test'):
+        return
+
     params.update({
         'v': '1',
         # FIXME: turn this into a setting. the complexity is that it's
@@ -41,7 +44,7 @@ def ga_track_event(params, async=True):
 
     # If we're in DEBUG mode or running tests, we don't want to hose
     # production data, so we prepend test_ to the category.
-    if 'ec' in params and (settings.DEBUG or 'test' in sys.argv):
+    if 'ec' in params and settings.DEBUG:
         params['ec'] = 'test_' + params['ec']
 
     if async:

--- a/fjord/base/google_utils.py
+++ b/fjord/base/google_utils.py
@@ -31,6 +31,12 @@ def ga_track_event(params, async=True):
        testing/development data hosing your production data.
 
     """
+    # FIXME: We should only have the google id in settings in
+    # production and not anywhere else. Thus when not running in
+    # production, this function would check that setting, notice it
+    # was blank and then exit. Then we don't have to do this goofy
+    # "are we testing?" test which breaks when we change our testing
+    # infrastructure.
     if sys.argv and sys.argv[0].endswith('py.test'):
         return
 
@@ -42,8 +48,8 @@ def ga_track_event(params, async=True):
         't': 'event'
     })
 
-    # If we're in DEBUG mode or running tests, we don't want to hose
-    # production data, so we prepend test_ to the category.
+    # If we're in DEBUG mode, we don't want to hose production data,
+    # so we prepend test_ to the category.
     if 'ec' in params and settings.DEBUG:
         params['ec'] = 'test_' + params['ec']
 

--- a/fjord/base/tests/test_google_utils.py
+++ b/fjord/base/tests/test_google_utils.py
@@ -4,6 +4,8 @@ from functools import wraps
 import requests_mock
 from mock import MagicMock, patch
 
+from django.test.utils import override_settings
+
 from fjord.base.google_utils import GOOGLE_API_URL, ga_track_event
 from fjord.base.tests import TestCase
 
@@ -33,8 +35,9 @@ def set_sys_argv(sys_argv):
 
 
 class TestGoogleUtils(TestCase):
-    @set_sys_argv(['test'])
-    def test_ga_track_event_test(self):
+    @override_settings(DEBUG=True)
+    @set_sys_argv([])
+    def test_ga_track_event_debug_prefixes_with_test(self):
         with patch('fjord.base.google_utils.requests') as req_patch:
             # Create a mock that we can call .post() on and query what
             # it got params-wise. It doesn't matter what the return
@@ -77,24 +80,32 @@ class TestGoogleUtils(TestCase):
                 }
             )
 
+    @set_sys_argv([])
     def test_ga_track_event_async_true(self):
         """async=True, then delay() gets called once"""
         with requests_mock.Mocker() as m:
             m.post(GOOGLE_API_URL, text='')
 
-            d = 'fjord.base.google_utils.post_event.delay'
-            with patch(d) as delay_patch:
-                params = {'cid': 'xxx', 'ec': 'ou812'}
-                ga_track_event(params, async=True)
-                assert delay_patch.call_count == 1
+            post_event = 'fjord.base.google_utils.post_event'
+            post_event_delay = 'fjord.base.google_utils.post_event.delay'
+            with patch(post_event) as post_event_patch:
+                with patch(post_event_delay) as post_event_delay_patch:
+                    params = {'cid': 'xxx', 'ec': 'ou812'}
+                    ga_track_event(params, async=True)
+                    assert post_event_patch.call_count == 0
+                    assert post_event_delay_patch.call_count == 1
 
+    @set_sys_argv([])
     def test_ga_track_event_async_false(self):
         """async=False, then delay() never gets called"""
         with requests_mock.Mocker() as m:
             m.post(GOOGLE_API_URL, text='')
 
-            d = 'fjord.base.google_utils.post_event.delay'
-            with patch(d) as delay_patch:
-                params = {'cid': 'xxx', 'ec': 'ou812'}
-                ga_track_event(params, async=False)
-                assert delay_patch.call_count == 0
+            post_event = 'fjord.base.google_utils.post_event'
+            post_event_delay = 'fjord.base.google_utils.post_event.delay'
+            with patch(post_event) as post_event_patch:
+                with patch(post_event_delay) as post_event_delay_patch:
+                    params = {'cid': 'xxx', 'ec': 'ou812'}
+                    ga_track_event(params, async=False)
+                    assert post_event_patch.call_count == 1
+                    assert post_event_delay_patch.call_count == 0

--- a/fjord/base/tests/test_google_utils.py
+++ b/fjord/base/tests/test_google_utils.py
@@ -20,6 +20,12 @@ def set_sys_argv(sys_argv):
             def test_something(self):
                 ...
 
+    .. warning::
+
+       Since ``sys.argv`` could be used by anything, changing it in
+       this manner could have unintended side-effects. You have been
+       warned!
+
     """
     def _set_sys_argv(fun):
         @wraps(fun)


### PR DESCRIPTION
We have a handful of google_utils tests that need to test that function.
This fixes them so they're all mocked and none of them send actual data.

We have a bunch of other tests that test code that calls google_utils
functions. This fixes the google_utils functions to not send any data
when running in a test context.

r?