### PR TITLE
[bug 1146686] Fix triggerrule testing

### DIFF
--- a/fjord/suggest/providers/trigger/static/js/triggerrule.js
+++ b/fjord/suggest/providers/trigger/static/js/triggerrule.js
@@ -94,15 +94,26 @@
         }
 
         /**
+         * Converts a \n delimited text blob into an array.
+         *
+         * @param {String} The \n delimited text.
+         *
+         * @returns {Array} An array of strings.
+         */
+        function textToArray(value) {
+            return value.split('\n').filter(function (val) { return val !== ''; });
+        }
+
+        /**
          * Pulls values from form, sets up data, performs API call and when
          * that returns, generates the matches on the page.
          */
         function getMatches() {
             var data = {
-                locales: $('#id_locales').val().split('\n'),
+                locales: textToArray($('#id_locales').val()),
                 products: [],
-                versions: $('#id_versions').val().split('\n'),
-                keywords: $('#id_keywords').val().split('\n'),
+                versions: textToArray($('#id_versions').val()),
+                keywords: textToArray($('#id_keywords').val()),
                 url_exists: null
             };
             // product is in a select and we want the text--not the value.


### PR DESCRIPTION
The triggerrule testing thing was sending [''] for fields like locale
which are \n delimited textareas. That now causes an HTTP 400 error.

This fixes that by filtering out empty strings before generating the
request to send to the API.

Note: This commit was buried in the django-1.8 pr. I cherry-picked it and removed it from the Django 1.8 pr.

r?