### PR TITLE
Properly name the vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,6 +78,9 @@ Vagrant.configure(2) do |config|
 
     # Customize the amount of memory on the VM:
     vb.memory = CONF['memory']
+
+    # Set the name of the VM
+    vb.name = "fjord-dev"
   end
   #
   # View the documentation for the provider you are using for more


### PR DESCRIPTION
Name the vagrant VM as 'fjord-dev' instead of letting vagrant
name it as fjord_default_<some long random number>.