### PR TITLE
[bug 1216624] Add --check-header to msgfmt run

### DIFF
--- a/bin/compile-linted-mo.sh
+++ b/bin/compile-linted-mo.sh
@@ -22,6 +22,8 @@ function compilemo() {
     then
         mv "${targettmp}" "${target}"
     fi
+
+    rm -rf "${targettmp}"
 }
 
 # Get the path to the python binary from the "-p <PYTHON>"

--- a/bin/compile-linted-mo.sh
+++ b/bin/compile-linted-mo.sh
@@ -8,8 +8,20 @@ function compilemo() {
     dir=`dirname $1`
     stem=`basename $1 .po`
 
+    target="${dir}/${stem}.mo"
+    targettmp="${dir}/${stem}.mo.tmp"
+
     echo "Compiling $1..."
-    msgfmt -o "${dir}/${stem}.mo" "$1"
+
+    # Run msgfmt which will compile the .mo file
+    msgfmt --check-header -o "${targettmp}" "$1"
+
+    # If msgfmt returned a zero exit code, then everything is fine and copy
+    # the .mo file to the final destination
+    if [ $? -eq 0 ]
+    then
+        mv "${targettmp}" "${target}"
+    fi
 }
 
 # Get the path to the python binary from the "-p <PYTHON>"


### PR DESCRIPTION
This will cause msgfmt to check the headers of the .po file before it
compiles it to a .mo file. In most cases, the header values don't matter
a lot. However, this validates the Plural-Forms header which is important.

If Plural-Forms header is invalid, then msgfmt will exit with a status
code of 1 and we don't replace the existing .mo file. If it's fine,
then we copy the targettmp file to the destination and we're good to go.

r?