### PR TITLE
Fix msg length

### DIFF
--- a/fjord/journal/models.py
+++ b/fjord/journal/models.py
@@ -12,10 +12,34 @@ RECORD_INFO = u'info'
 RECORD_ERROR = u'error'
 
 
+def goofy_truncate(text, length):
+    """This truncates text accounting for utf-8 sequences
+
+    This assumes a limited number of bytes of storage, but that we
+    want to maintain utf-8 sequences. Thus it does this goofy loop
+    to make sure we don't break a sequence, but that the result
+    is correctly truncated.
+
+    :arg text: either unicode or str
+    :arg length: the number of bytes to truncate to
+
+    :returns: utf-8 encoded string
+    """
+    text = unicode(text)
+
+    while len(text.encode('utf-8')) > length:
+        if len(text) > 255:
+            text = text[:255]
+        else:
+            text = text[:-1]
+    return text.encode('utf-8')
+
+
 class RecordManager(models.Manager):
     @classmethod
     def log(cls, type_, app, src, action, msg, instance=None, metadata=None):
-        msg = msg.encode('utf-8')
+        msg = goofy_truncate(msg, 255)
+
         metadata = metadata or {}
 
         rec = Record(

--- a/fjord/journal/tests/test_models.py
+++ b/fjord/journal/tests/test_models.py
@@ -1,8 +1,18 @@
 from datetime import datetime, timedelta
 
 from fjord.base.tests import TestCase
-from fjord.journal.models import purge_data, Record
+from fjord.journal.models import goofy_truncate, purge_data, Record
 from fjord.journal.tests import RecordFactory
+
+
+def test_goofy_truncate():
+    tests = [
+        ('abcde', 5, 'abcde'),
+        ('abcde', 3, 'abc'),
+        (u'abcd\u20ac', 5, 'abcd'),
+    ]
+    for text, length, expected in tests:
+        assert goofy_truncate(text, length) == expected
 
 
 class TestPurgeData(TestCase):


### PR DESCRIPTION
If the msg is too long, then it throws a db error. This truncates the
msg value.