### PR TITLE
[bug 1218381] Fix run_l10n_completion runs

### DIFF
--- a/bin/crontab/crontab.tpl
+++ b/bin/crontab/crontab.tpl
@@ -9,7 +9,7 @@ HOME=/tmp
 # Once a day at 2:00am run the l10n completion script.
 # Note: This runs as root so it has access to the locale/ directory
 # to do an svn up.
-10 2 * * * root cd {{ source }} && (./bin/run_l10n_completion.sh {{ source }} {{ python }})
+10 2 * * * root cd {{ source }} && (./bin/run_l10n_completion.sh {{ webapp }} {{ python }})
 
 # Once a day at 3:00am run the translation daily activites.
 0 3 * * * {{ user }} cd {{ source }} && {{ python }} manage.py translation_daily -v 0 --traceback


### PR DESCRIPTION
It looks like the script is running just fine, but it's putting the
file in the source tree rather than the web tree and that's not
correct. We need to put it in the web tree so that it's available
everywhere.

Pretty sure this should fix it.

r?