### PR TITLE
[bug 1221252] Fix url field handling for feedback

### DIFF
--- a/fjord/feedback/config.py
+++ b/fjord/feedback/config.py
@@ -1,6 +1,10 @@
 from django.utils.translation import ugettext_lazy as _lazy
 
 
+# Maximum length for values in the url field of feedback Responses. We don't
+# want to use this to validate urls, but we do want to use this to truncate.
+URL_LENGTH = 1000
+
 # List of (value, name, _lazy(name)) tuples for countries Firefox OS has
 # been released in.
 # Values are ISO 3166 country codes.

--- a/fjord/feedback/forms.py
+++ b/fjord/feedback/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 
 from fjord.base.forms import EnhancedURLField
+from fjord.feedback.config import URL_LENGTH
 
 
 class URLInput(forms.TextInput):
@@ -33,3 +34,11 @@ class ResponseForm(forms.Form):
         attrs={'class': 'manufacturer'}))
     device = forms.CharField(required=False, widget=forms.HiddenInput(
         attrs={'class': 'device'}))
+
+    def clean_url(self):
+        # Truncate the url if it's > URL_LENGTH characters. We truncate rather
+        # than use it to validate because it probably doesn't matter if we keep
+        # super long urls and we'd rather not error out on the user.
+        data = self.cleaned_data['url']
+        data = data[:URL_LENGTH]
+        return data

--- a/fjord/feedback/migrations/0009_auto_20151111_1518.py
+++ b/fjord/feedback/migrations/0009_auto_20151111_1518.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import fjord.base.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0008_auto_20151014_0820'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='response',
+            name='url',
+            field=fjord.base.models.EnhancedURLField(max_length=1000, blank=True),
+        ),
+    ]

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -30,6 +30,10 @@ from fjord.translations.models import get_translation_system_choices
 from fjord.translations.tasks import register_auto_translation
 
 
+# Maximum length for urls
+URL_LENGTH = 1000
+
+
 class ProductManager(models.Manager):
     def public(self):
         """Returns publicly visible products"""
@@ -159,7 +163,7 @@ class Response(ModelBase):
 
     # Data coming from the user
     happy = models.BooleanField(default=True)
-    url = EnhancedURLField(blank=True)
+    url = EnhancedURLField(blank=True, max_length=1000)
     description = models.TextField()
 
     # Translation into English of the description
@@ -637,7 +641,7 @@ class PostResponseSerializer(serializers.Serializer):
     # this and instead default it to False.
     happy = serializers.BooleanField(default=False)
 
-    url = serializers.CharField(max_length=200, allow_blank=True, default=u'')
+    url = serializers.CharField(allow_blank=True, default=u'')
     description = serializers.CharField(required=True)
 
     category = serializers.CharField(
@@ -689,6 +693,7 @@ class PostResponseSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     u'{0} is not a valid url'.format(value)
                 )
+            value = value[:URL_LENGTH]
         return value
 
     def validate_product(self, value):

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -12,6 +12,7 @@ from fjord.base.tests import (
     TestCase,
 )
 from fjord.feedback import models
+from fjord.feedback.config import URL_LENGTH
 from fjord.feedback.tests import ProductFactory, ResponseFactory
 
 
@@ -635,6 +636,20 @@ class TestFeedback(TestCase):
         })
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.url == u''
+
+    def test_url_max_length(self):
+        """Long urls are truncated"""
+        url = reverse('feedback', args=(u'firefox',))
+
+        url_base = 'http://example.com/'
+        url_value = url_base + ('a' * (URL_LENGTH - len(url_base))) + 'b'
+        self.client.post(url, {
+            'url': url_value,
+            'happy': 0,
+            'description': u'foo'
+        })
+        feedback = models.Response.objects.latest(field_name='id')
+        assert feedback.url == url_value[:-1]
 
     def test_email_collection(self):
         """If the user enters an email and checks the box, collect email."""


### PR DESCRIPTION
This changes the url field to be 1000 characters. Further, it changes
the API and the feedback form handler to allow urls bigger than 1000
characters, but truncate them. It adds a test for the feedback form
handler and fixes the api test. On top of that, it centralizes the
magic number to the config file so I can more easily change it.