### PR TITLE
[bug 1224014] Fix user agent length issues

### DIFF
--- a/fjord/feedback/config.py
+++ b/fjord/feedback/config.py
@@ -5,6 +5,13 @@ from django.utils.translation import ugettext_lazy as _lazy
 # want to use this to validate urls, but we do want to use this to truncate.
 URL_LENGTH = 1000
 
+# Maximum length for values in the user-agent field of feedback Responses. We
+# don't want to use this to validate user agents, but we do want to use this to
+# truncate. With user agents, we risk losing important information at the end
+# of the value and also messing up the syntax, but I claim it won't have any
+# impact on how we use the data.
+USER_AGENT_LENGTH = 1000
+
 # List of (value, name, _lazy(name)) tuples for countries Firefox OS has
 # been released in.
 # Values are ISO 3166 country codes.

--- a/fjord/feedback/migrations/0010_auto_20151112_0708.py
+++ b/fjord/feedback/migrations/0010_auto_20151112_0708.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0009_auto_20151111_1518'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='response',
+            name='user_agent',
+            field=models.CharField(max_length=1000, blank=True),
+        ),
+    ]

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -12,7 +12,7 @@ from fjord.base.tests import (
     TestCase,
 )
 from fjord.feedback import models
-from fjord.feedback.config import URL_LENGTH
+from fjord.feedback.config import URL_LENGTH, USER_AGENT_LENGTH
 from fjord.feedback.tests import ProductFactory, ResponseFactory
 
 
@@ -650,6 +650,23 @@ class TestFeedback(TestCase):
         })
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.url == url_value[:-1]
+
+    def test_user_agent_max_length(self):
+        """Long user agents are truncated"""
+        url = reverse('feedback', args=(u'firefox',))
+
+        ua = (
+            'Mozilla/5.0 (' +
+            ('a' * USER_AGENT_LENGTH) +
+            ') Gecko/24.0 Firefox/24.0'
+        )
+        data = {
+            'happy': 0,
+            'description': u'foo'
+        }
+        self.client.post(url, data, HTTP_USER_AGENT=ua)
+        feedback = models.Response.objects.latest(field_name='id')
+        assert feedback.user_agent == ua[:USER_AGENT_LENGTH]
 
     def test_email_collection(self):
         """If the user enters an email and checks the box, collect email."""

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -160,12 +160,13 @@ def _handle_feedback_post(request, locale=None, product=None,
     if user_agent:
         browser = request.BROWSER
 
-        opinion.user_agent = user_agent
-        opinion.browser = browser.browser
-        opinion.browser_version = browser.browser_version
-        opinion.browser_platform = browser.platform
-        if browser.platform == 'Windows':
-            opinion.browser_platform += ' ' + browser.platform_version
+        opinion.browser = browser.browser[:30]
+        opinion.browser_version = browser.browser_version[:30]
+        bp = browser.platform
+        if bp == 'Windows':
+            bp += (' ' + browser.platform_version)
+        opinion.browser_platform = bp[:30]
+        opinion.user_agent = user_agent[:config.USER_AGENT_LENGTH]
 
     # source is src or utm_source
     source = (
@@ -221,10 +222,10 @@ def _handle_feedback_post(request, locale=None, product=None,
                         product_db_name, request.BROWSER)
 
     # Make sure values are at least empty strings--no Nones.
-    opinion.product = product_db_name or u''
-    opinion.version = version or u''
-    opinion.channel = channel or u''
-    opinion.platform = platform or u''
+    opinion.product = (product_db_name or u'')[:30]
+    opinion.version = (version or u'')[:30]
+    opinion.channel = (channel or u'')[:30]
+    opinion.platform = (platform or u'')[:30]
 
     opinion.save()
 


### PR DESCRIPTION
This changes the field to hold up to 1000 characters. Further, it
changes the code for both the feedback handling view and the api to
truncate user agents longer than 1000 characters. It adds tests. It
centralizes the length in a config constant.