### PR TITLE
Add source param to secret histogram api

### DIFF
--- a/fjord/analytics/analyzer_views.py
+++ b/fjord/analytics/analyzer_views.py
@@ -124,7 +124,7 @@ def analytics_search(request):
     search_has_email = request.GET.get('has_email', None)
     search_country = request.GET.get('country', None)
     search_domain = request.GET.get('domain', None)
-    search_api = smart_int(request.GET.get('api', None), fallback=None)
+    search_api = request.GET.get('api', None)
     search_source = request.GET.get('source', None)
     search_campaign = request.GET.get('campaign', None)
     search_organic = request.GET.get('organic', None)

--- a/fjord/feedback/api_views.py
+++ b/fjord/feedback/api_views.py
@@ -57,6 +57,19 @@ class FeedbackHistogramAPI(rest_framework.views.APIView):
                     if versions:
                         f &= F('terms', version=versions)
 
+        if 'source' in request.GET:
+            # FIXME: Having a , in the source is valid, so this might not work
+            # right.
+            sources = request.GET['source'].split(',')
+            if sources:
+                f &= F('terms', source=sources)
+
+        if 'api' in request.GET:
+            # The int (as a str) or "None"
+            apis = request.GET['api'].split(',')
+            if apis:
+                f &= F('terms', api=apis)
+
         date_start = smart_date(request.GET.get('date_start', None))
         date_end = smart_date(request.GET.get('date_end', None))
         delta = smart_timedelta(request.GET.get('date_delta', None))

--- a/fjord/feedback/models.py
+++ b/fjord/feedback/models.py
@@ -457,7 +457,7 @@ class ResponseDocTypeManager(FjordDocTypeManager):
 class ResponseDocType(FjordDocType):
     id = es_dsl.Integer()
     happy = es_dsl.Boolean()
-    api = es_dsl.Integer()
+    api = es_dsl.String(index='not_analyzed')
     url = es_dsl.String(index='not_analyzed')
     url_domain = es_dsl.String(index='not_analyzed')
     has_email = es_dsl.Boolean()
@@ -573,7 +573,9 @@ class ResponseDocType(FjordDocType):
         doc = {
             'id': resp.id,
             'happy': resp.happy,
-            'api': resp.api,
+            # This is an int or None, but we convert it to a str which
+            # converts the None and gives us values that are easier to query.
+            'api': str(resp.api),
             'url': resp.url,
             'url_domain': resp.url_domain,
             'has_email': bool(resp.user_email),

--- a/fjord/feedback/tests/test_api.py
+++ b/fjord/feedback/tests/test_api.py
@@ -414,6 +414,7 @@ class TestFeedbackHistogramAPI(ElasticTestCase):
     # FIXME: Test happy/sad
     # FIXME: Test platforms
     # FIXME: Test interval
+    # FIXME: Test source
 
 
 class TestPostFeedbackAPI(TestCase):


### PR DESCRIPTION
This adds a "source" param to the secret histogram api. We can use this for dashboards that want to track how many feedback we're getting broken down by source.