### PR TITLE
[bug 1225937] Fix UnboundLocalError in gengo maintenance admin page

### DIFF
--- a/fjord/translations/admin.py
+++ b/fjord/translations/admin.py
@@ -57,6 +57,7 @@ def gengo_translator_view(request):
     gengo_languages = None
     missing_prod_locales = None
     outstanding = []
+    seven_days_of_orders = []
 
     if settings.GENGO_PUBLIC_KEY and settings.GENGO_PRIVATE_KEY:
         gengo_api = FjordGengo()
@@ -113,7 +114,7 @@ def gengo_translator_view(request):
             for i in range(7)
         ]
 
-        seven_days_of_orders = []
+
         for day in sorted(days):
             seven_days_of_orders.append(
                 (day,


### PR DESCRIPTION
Fixed the error for the 'seven_days_of_orders' variable