### PR TITLE
[bug 1225676] Port fennec feedback form to web

### DIFF
--- a/fjord/feedback/jinja2/feedback/android_feedback.html
+++ b/fjord/feedback/jinja2/feedback/android_feedback.html
@@ -197,8 +197,8 @@
           </g>
         </g>
       </svg>
-      {% trans %}
-        Visit our <a href="https://support.mozilla.org/products/mobile/popular-articles-android?as=u&utm_source=inproduct">Support Site</a> to get answers for common issues.
+      {% trans support_url="https://support.mozilla.org/products/mobile/popular-articles-android?as=u&utm_source=inproduct" %}
+        Visit our <a href="{{support_url}}">Support Site</a> to get answers for common issues.
         {% endtrans %}
     </div>{# .help-section #}
   </div>{# .footer.sad #}

--- a/fjord/feedback/jinja2/feedback/android_feedback.html
+++ b/fjord/feedback/jinja2/feedback/android_feedback.html
@@ -1,0 +1,205 @@
+{% extends "base.html" %}
+
+{% block extra_headers %}
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+{% endblock %}
+
+{% block site_js %}
+  {% javascript 'android_feedback' %}
+{% endblock %}
+
+{% block site_css %}
+  {% stylesheet 'android-feedback' %}
+{% endblock %}
+
+{# L10N note: In order to reduce the work required by translators
+ # to launch the initial port of this form, we copied localized
+ # strings directly from Fennec (see bug 1235419). We can/should
+ # fix strings after launch.
+ #}
+{% block page_title %}{{ _('Firefox Feedback') }}{% endblock %}
+
+{% set extra_body_attrs =
+  {
+    'data-form-name': 'android',
+    'data-version': version,
+    'data-channel': channel
+  }
+%}
+
+{% block body_id %}android{% endblock %}
+
+{% block body %}
+  <div class="main">
+    {% block content %}
+        <div class="content">
+
+          <div class="deck">
+            <div class="card no-back" id="intro">
+              <section>
+
+                <h1>
+                  {% trans %}
+                    Have a minute?
+                  {% endtrans %}
+                </h1>
+                <div class="message">
+                  {% trans product=product.display_name %}
+                    Tell us what you think about {{product}} so far.
+                  {% endtrans %}
+                </div>
+
+                <noscript>
+                  <p class="error">
+                    {% trans %}
+                      JavaScript is required to leave feedback. Please enable JavaScript in your browser and refresh this page.
+                    {% endtrans %}
+                  </p>
+                </noscript>
+
+                <div id="happy-button" class="link-box sentiment-button" tabindex=0>
+                  <a>
+                    {% trans %}
+                      I love it
+                    {% endtrans %}
+                  </a>
+                </div>{# #happy-button #}
+
+                <div id="sad-button" class="link-box sentiment-button" tabindex=0>
+                  <a>
+                    {% trans %}
+                      I ran into some problems
+                    {% endtrans %}
+                  </a>
+                </div>{# #sad-button #}
+
+              </section>
+            </div>{# #intro.card #}
+
+            <div class="card inactive" id="moreinfo" data-focus="#description" data-back-id="intro">
+              <section>
+                <div class="happy">
+                  <h1>
+                    {% trans %}
+                      That's great to hear!
+                    {% endtrans %}
+                  </h1>
+
+                  <div class="message-box">
+                    <div class="message">
+                      {% trans %}
+                        Want to share the love by giving us a 5 star rating on
+                        Google Play?
+                      {% endtrans %}
+                    </div>{# .message #}
+                    <div>
+                      {% trans %}
+                        It takes less than a minute and feels great.
+                      {% endtrans %}
+                    </div>
+                    <a class="stars" id="play-store" data-event="FeedbackOpenPlay" href="#">
+                      <svg>
+                        <defs>
+                          <symbol viewBox="0 0 100 100" id="star">
+                            <polygon points="48 75 18.6107374 90.4508497 24.2235871 57.7254249 0.447174185 34.5491503 33.3053687 29.7745751 48 0 62.6946313 29.7745751 95.5528258 34.5491503 71.7764129 57.7254249 77.3892626 90.4508497" class="star" xmlns="http://www.w3.org/2000/svg" fill="#0092db"></polygon>
+                          </symbol>
+                        </defs>
+                        <use width="25" height="25" xlink:href="#star" x="0" y="0"></use>
+                        <use width="25" height="25" xlink:href="#star" x="25" y="0"></use>
+                        <use width="25" height="25" xlink:href="#star" x="50" y="0"></use>
+                        <use width="25" height="25" xlink:href="#star" x="75" y="0"></use>
+                        <use width="25" height="25" xlink:href="#star" x="100" y="0"></use>
+                      </svg>
+                      {% trans %}
+                        Yes, go to Google Play
+                      {% endtrans %}
+                    </a>
+                  </div>{# .message-box #}
+                </div>{# .happy #}
+
+                <div class="sad">
+                  <h1>
+                    {% trans %}
+                      Oh no!
+                    {% endtrans %}
+                  </h1>
+
+                  <div class="ask">
+                    <form id="responseform" action="" method="post">
+                      <div class="input-box">
+                        <label for="description">
+                          {% trans %}
+                            We're sorry that you had some problems with Firefox.
+                            Please tell us what happened so that we can fix it.
+                          {% endtrans %}
+                        </label>
+                        <div id="description-counter">{{ TRUNCATE_LENGTH }}</div>
+                        <textarea data-max-length="{{ TRUNCATE_LENGTH }}" id="description" name="description" placeholder="Enter your feedback here"></textarea>
+                      </div>{# .input-box #}
+
+                      <div class="input-box">
+                        <label for="id_url">
+                          {% trans %}
+                            Include last visited site
+                          {% endtrans %}
+                          <input id="last-checkbox" type="checkbox" checked="checked"/>
+                          <input class="url" id="id_url" name="url" placeholder="http://" type="text">
+                        </label>
+                      </div>{# .input-box #}
+
+                      {% for hidden in form.hidden_fields() %}
+                        {{ hidden }}
+                      {% endfor %}
+                      {% csrf_token %}
+
+                      <div class="input-box">
+                        <input type="submit" value="{{ _('Send Feedback') }}" id="form-submit-btn" class="complete btn submit" disabled="disabled">
+                        </input>
+                      </div>{# .input-box #}
+
+                      <div class="privacy">
+                        {% trans %}
+                          For your privacy, please do not include any personal information
+                          in your feedback.
+                        {% endtrans %}
+                      </div>{# .privacy #}
+                    </form>
+                  </div>{# .ask #}
+
+                </div>{# .sad #}
+              </section>
+            </div>{# #moreinfo.card #}
+          </div>{# .deck #}
+        </div>{# .content #}
+
+    {% endblock %}
+  </div>
+  <div class="footer happy">
+    <a id="maybe-later" data-event="FeedbackMaybeLater" href="#">
+      {% trans %}
+        Maybe later
+      {% endtrans %}
+    </a>
+    <a id="no-thanks" data-event="FeedbackClose" href="#">
+      {% trans %}
+        No thanks
+      {% endtrans %}
+    </a>
+  </div>{# .footer.happy #}
+  <div class="footer sad">
+    <div class="help-section">
+      <svg viewBox="0 0 156 156">
+        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g transform="translate(3.000000, 2.000000)">
+              <ellipse stroke="#DE1920" stroke-width="6" fill="#FFFFFF" transform="translate(75.008751, 75.991249) rotate(-270.000000) translate(-75.008751, -75.991249) " cx="75.008751" cy="75.991249" rx="75.008751" ry="75.008751"></ellipse>
+              <path d="M114.879498,75.7124061 L150.016995,75.7124061 C149.8667,34.4144668 116.341953,0.982498052 75.008751,0.982498052 C74.7295491,0.982498052 74.4507036,0.98402351 74.1722222,0.987066548 L74.1722222,36.1205023 C74.357816,36.1179759 74.543714,36.1167085 74.729908,36.1167085 C96.7198153,36.1167085 114.581115,53.7933778 114.879498,75.7124061 Z M74.729908,116.423475 L74.729908,150.999529 C33.4319688,150.849198 0,117.324451 0,75.991249 C0,75.8982618 0.000169204083,75.805314 0.000507321153,75.7124061 L34.5803184,75.7124061 C34.5777919,75.8979999 34.5765246,76.083898 34.5765246,76.270092 C34.5765246,98.4461933 52.5538067,116.423475 74.729908,116.423475 Z" fill="#DE1920" transform="translate(75.008497, 75.990995) rotate(-270.000000) translate(-75.008497, -75.990995) "></path>
+              <ellipse stroke="#DE1920" stroke-width="6" fill-opacity="0" transform="translate(74.729908, 76.270092) rotate(-270.000000) translate(-74.729908, -76.270092) " cx="74.729908" cy="76.270092" rx="40.1533834" ry="40.1533834"></ellipse>
+          </g>
+        </g>
+      </svg>
+      {% trans %}
+        Visit our <a href="https://support.mozilla.org/products/mobile/popular-articles-android?as=u&utm_source=inproduct">Support Site</a> to get answers for common issues.
+        {% endtrans %}
+    </div>{# .help-section #}
+  </div>{# .footer.sad #}
+{% endblock %}

--- a/fjord/feedback/jinja2/feedback/android_thanks.html
+++ b/fjord/feedback/jinja2/feedback/android_thanks.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block extra_headers %}
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+{% endblock %}
+
+{% block site_js %}
+  {% javascript 'android_feedback' %}
+{% endblock %}
+
+{% block site_css %}
+  {% stylesheet 'android-feedback' %}
+{% endblock %}
+
+{# L10N note: In order to reduce the work required by translators
+ # to launch the initial port of this form, we copied localized
+ # strings directly from Fennec (see bug 1235419). We can/should
+ # fix strings after launch.
+ #}
+{% block page_title %}{{ _('Firefox Feedback') }}{% endblock %}
+
+{% block body_id %}android{% endblock %}
+
+{% block body %}
+  <div class="main">
+
+    {% block content %}
+      <div class="content">
+        <div class="deck">
+          <div class="card no-back" id="thanks">
+            <section>
+
+              <h1>
+                {% trans %}
+                  Thank you.
+                {% endtrans %}
+              </h1>
+              <div class="message heart">
+                <svg viewBox="0 0 100 110">
+                  <path d="M4.20152102,44.5344113 C-12.8987227,5.08506476 37.2648073,-17.6397688 50.6373929,18.0189693 C63.9576781,-17.6397683 114.277469,5.08506476 97.1772249,44.5344113 C91.8645859,55.9698934 52.2858248,83.7136852 50.5850925,90.6483352 C48.9013298,83.7202158 9.80833953,55.370549 4.20152102,44.5344113 Z" fill="#DE1920"></path>
+                </svg>
+                {% trans %}
+                  We're always working to make Firefox better.
+                  Rest assured that real people will look at your feedback 
+                  and do their very best to resolve your issue.
+                {% endtrans %}
+              </div>
+              <div class="message">
+                {% trans %}
+                  Or else.
+                {% endtrans %}
+              </div>
+            </section>
+          </div>{# #thanks #}
+        </div>{# .deck #}
+      </div>{# .content #}
+    {% endblock %}
+
+  </div>{# .main #}
+  <div class="footer sad show">
+    <div class="help-section">
+      <svg viewBox="0 0 156 156">
+        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g transform="translate(3.000000, 2.000000)">
+              <ellipse stroke="#DE1920" stroke-width="6" fill="#FFFFFF" transform="translate(75.008751, 75.991249) rotate(-270.000000) translate(-75.008751, -75.991249) " cx="75.008751" cy="75.991249" rx="75.008751" ry="75.008751"></ellipse>
+              <path d="M114.879498,75.7124061 L150.016995,75.7124061 C149.8667,34.4144668 116.341953,0.982498052 75.008751,0.982498052 C74.7295491,0.982498052 74.4507036,0.98402351 74.1722222,0.987066548 L74.1722222,36.1205023 C74.357816,36.1179759 74.543714,36.1167085 74.729908,36.1167085 C96.7198153,36.1167085 114.581115,53.7933778 114.879498,75.7124061 Z M74.729908,116.423475 L74.729908,150.999529 C33.4319688,150.849198 0,117.324451 0,75.991249 C0,75.8982618 0.000169204083,75.805314 0.000507321153,75.7124061 L34.5803184,75.7124061 C34.5777919,75.8979999 34.5765246,76.083898 34.5765246,76.270092 C34.5765246,98.4461933 52.5538067,116.423475 74.729908,116.423475 Z" fill="#DE1920" transform="translate(75.008497, 75.990995) rotate(-270.000000) translate(-75.008497, -75.990995) "></path>
+              <ellipse stroke="#DE1920" stroke-width="6" fill-opacity="0" transform="translate(74.729908, 76.270092) rotate(-270.000000) translate(-74.729908, -76.270092) " cx="74.729908" cy="76.270092" rx="40.1533834" ry="40.1533834"></ellipse>
+          </g>
+        </g>
+      </svg>
+      {% trans %}
+        Visit our <a href="https://support.mozilla.org/en-US/products/mobile/popular-articles-android?as=u&utm_source=inproduct">Support Site</a> to get answers for common issues.
+      {% endtrans %}
+    </div>{# .help-section #}
+  </div>{# .footer.sad #}
+{% endblock %}

--- a/fjord/feedback/jinja2/feedback/android_thanks.html
+++ b/fjord/feedback/jinja2/feedback/android_thanks.html
@@ -68,8 +68,8 @@
           </g>
         </g>
       </svg>
-      {% trans %}
-        Visit our <a href="https://support.mozilla.org/en-US/products/mobile/popular-articles-android?as=u&utm_source=inproduct">Support Site</a> to get answers for common issues.
+      {% trans support_url="https://support.mozilla.org/products/mobile/popular-articles-android?as=u&utm_source=inproduct" %}
+        Visit our <a href="{{support_url}}">Support Site</a> to get answers for common issues.
       {% endtrans %}
     </div>{# .help-section #}
   </div>{# .footer.sad #}

--- a/fjord/feedback/static/css/android-feedback.less
+++ b/fjord/feedback/static/css/android-feedback.less
@@ -1,0 +1,179 @@
+/* OVERRIDE generic feedback styles */
+
+body {
+  font-family: sans-serif;
+  font-size: 12px;
+  color: #222;
+  background-color: #f5f5f5;
+  margin: 0px;
+}
+
+.main {
+  padding: 0px;
+}
+
+.content {
+  padding: 25px;
+}
+
+section {
+  margin: 0px;
+}
+
+h1 {
+  font-size: 24px;
+  font-weight: lighter;
+  text-align: center;
+  margin-top: 0px;
+}
+
+a {
+  color: #0092db;
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+textarea {
+  height: 35vh;
+}
+
+/* COMMON FxA styles */
+.message {
+  margin-bottom: 10px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.message-box, .link-box {
+  background-color: #fff;
+  padding: 15px;
+  border-bottom: 1px solid #ebebf0;
+}
+
+.link-box {
+  text-align: center;
+}
+
+.link-box:active, .link-box-bottom:active {
+  background-color: #a7b0b8;
+}
+
+@media screen and (min-width: 500px) {
+  .message-box, .message {
+    text-align: center;
+  }
+}
+
+
+/* HAPPY styles */
+
+.stars {
+  text-align: center;
+  display: block;
+  width: 100%;
+  margin: 10px 0;
+  cursor: pointer;
+  svg {
+    width: 125px;
+    height: 25px;
+    margin: 10px auto;
+    display: block;
+  }
+}
+
+.footer.happy {
+  text-align: center;
+  width: 100%;
+  a {
+    margin: 0px 25px;
+    text-decoration: underline;
+  }
+}
+
+@media not screen and (max-height: 400px) {
+  .footer.happy {
+    position: absolute;
+    left: 0px;
+    bottom: 40px;
+  }
+}
+
+
+/* SAD styles */
+
+.input-box {
+  padding: 10px 0px;
+}
+
+#description-counter {
+  color: #0092db;
+}
+
+.privacy {
+  color: #bebebe;
+  margin-top: 10px;
+  text-align: center;
+}
+
+.btn.submit {
+  background: #8698a8;
+  padding: 15px;
+  font-size: 16px;
+  width: 100%;
+  border-radius: 4px;
+  border-width: 0px;
+  color: #fff;
+  margin: 0px auto;
+}
+
+.footer.sad {
+  display: none;
+  background-color: #ebe9f0;
+  border-top: 2px solid #d4d3d8;
+  position: fixed;
+  bottom: 0px;
+  width: 100%;
+  margin: 0px auto;
+  padding: 15px 0px;
+}
+
+.footer.sad.show {
+  display: block;
+}
+
+.help-section {
+  max-width: 500px;
+  padding: 5px;
+  overflow: hidden;
+  font-size: 16px;
+  svg {
+    float: left;
+    margin-right: 20px;
+    width: 31px;
+    height: 31px;
+  }
+}
+
+@media screen and (max-height: 450px) {
+  .footer.sad {
+    position: relative;
+  }
+}
+
+@media screen and (min-width: 500px) {
+  .help-section {
+    margin: auto;
+  }
+}
+
+/* THANKS styles */
+
+.heart {
+  svg {
+    width: 70px;
+    height: 70px;
+    display: block;
+    margin: 0 auto;
+  }
+}

--- a/fjord/feedback/static/js/android_feedback.js
+++ b/fjord/feedback/static/js/android_feedback.js
@@ -1,0 +1,66 @@
+(function($) {
+  'use strict';
+
+  // settings
+  var browserReviewUrl = 'https://play.google.com/store/apps/details?id=org.mozilla.CHANNEL#details-reviews';
+  var deviceReviewUrl = 'market://details?id=org.mozilla.CHANNEL';
+
+  // initialize
+  var reviewUrl, lastUrl = '';
+  var url = decodeURIComponent(window.location.href);
+
+
+  /*
+    Decide whether they're on Fx Android or not
+    (Fx Android's feedback prompt includes a utm param)
+  */
+  var fromDevice = /source=feedback-prompt/.test(url);
+  if (fromDevice) {
+    reviewUrl = deviceReviewUrl;
+    /* 
+      TODO: When bug 1237388 is resolved, remove #play-store here.
+      If url params are as assumed below, it'll Just Work(tm)!
+    */
+    $('#maybe-later, #no-thanks, #play-store').click(
+      function(e) {
+        e.preventDefault();
+        var feedbackEvent = document.createEvent('Events');
+        feedbackEvent.initEvent(this.getAttribute('data-event'), true, false);
+        this.dispatchEvent(feedbackEvent);
+      }
+    );
+  }
+  else {
+    reviewUrl = browserReviewUrl;
+    // if browsed here deliberately, no need for these
+    $('#maybe-later, #no-thanks').hide();
+  }
+
+  // decide what product they might review on play store
+  var version = $('body').attr('data-version');
+  var channel = $('body').attr('data-channel');
+  if (channel == 'beta') {
+    reviewUrl = reviewUrl.replace('CHANNEL', 'firefox_beta');
+  }
+  else if (channel != '' && /^(?!(beta|release)).*$/.test(channel)) {
+    // if they specify a channel not in play store, don't encourage review
+    $('.happy .message-box').hide();
+  }
+  else {
+    reviewUrl = reviewUrl.replace('CHANNEL', 'firefox');
+  }
+
+  $('#play-store').attr('href', reviewUrl);
+
+  // if they say don't send url in sad feedback, don't send url
+  $('#last-checkbox').click(function(e) {
+    if (this.checked) {
+      $('#id_url').val(lastUrl).prop('disabled', false);
+    }
+    else {
+      lastUrl = $('#id_url').val();
+      $('#id_url').val('').prop('disabled', 'disabled');
+    }
+  });
+
+}(jQuery));

--- a/fjord/feedback/static/js/android_feedback.js
+++ b/fjord/feedback/static/js/android_feedback.js
@@ -1,49 +1,44 @@
 (function($) {
   'use strict';
 
-  // settings
+  // Settings
   var browserReviewUrl = 'https://play.google.com/store/apps/details?id=org.mozilla.CHANNEL#details-reviews';
   var deviceReviewUrl = 'market://details?id=org.mozilla.CHANNEL';
 
-  // initialize
-  var reviewUrl, lastUrl = '';
-  var url = decodeURIComponent(window.location.href);
-
+  // Initialize
+  var reviewUrl = '';
+  var lastUrl = '';
+  var url = decodeURI(window.location.href);
 
   /*
-    Decide whether they're on Fx Android or not
-    (Fx Android's feedback prompt includes a utm param)
+    Decide whether they're here deliberately or due to a feedback prompt
+    (Fx Android's feedback prompt includes a utm param);
   */
   var fromDevice = /source=feedback-prompt/.test(url);
   if (fromDevice) {
     reviewUrl = deviceReviewUrl;
-    /* 
-      TODO: When bug 1237388 is resolved, remove #play-store here.
-      If url params are as assumed below, it'll Just Work(tm)!
-    */
-    $('#maybe-later, #no-thanks, #play-store').click(
-      function(e) {
+    /* If client prompted for feedback, delegate some event handling to the client */
+    $(document).on('click', '#maybe-later, #no-thanks', function(e) {
         e.preventDefault();
-        var feedbackEvent = document.createEvent('Events');
-        feedbackEvent.initEvent(this.getAttribute('data-event'), true, false);
+        var eventName = this.getAttribute('data-event');
+        var feedbackEvent = new Event(eventName, {"bubbles":true, "cancelable":false});
         this.dispatchEvent(feedbackEvent);
-      }
-    );
+    });
   }
   else {
     reviewUrl = browserReviewUrl;
-    // if browsed here deliberately, no need for these
+    // If browsed here deliberately, no need for these
     $('#maybe-later, #no-thanks').hide();
   }
 
-  // decide what product they might review on play store
+  // Decide what product they might review on play store
   var version = $('body').attr('data-version');
   var channel = $('body').attr('data-channel');
   if (channel == 'beta') {
     reviewUrl = reviewUrl.replace('CHANNEL', 'firefox_beta');
   }
   else if (channel != '' && /^(?!(beta|release)).*$/.test(channel)) {
-    // if they specify a channel not in play store, don't encourage review
+    // If they specify a channel not in play store, don't encourage review
     $('.happy .message-box').hide();
   }
   else {
@@ -53,13 +48,14 @@
   $('#play-store').attr('href', reviewUrl);
 
   // if they say don't send url in sad feedback, don't send url
+  var $id_url = $('#id_url').first();
   $('#last-checkbox').click(function(e) {
     if (this.checked) {
-      $('#id_url').val(lastUrl).prop('disabled', false);
+      $id_url.val(lastUrl).prop('disabled', false);
     }
     else {
       lastUrl = $('#id_url').val();
-      $('#id_url').val('').prop('disabled', 'disabled');
+      $id_url.val('').prop('disabled', 'disabled');
     }
   });
 

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -195,7 +195,6 @@ class TestFeedback(TestCase):
 
     def test_android_view(self):
         """Android returns correct view"""
-        # Specifying fxos as the product in the url
         url = reverse('feedback', args=(u'android',))
         r = self.client.get(url)
         assert template_used(r, 'feedback/android_feedback.html')
@@ -203,18 +202,15 @@ class TestFeedback(TestCase):
     def test_android_view_redirects_to_android_thanks(self):
         """Sad feedback in Android redirects to proper thanks template"""
         url = reverse('feedback', args=(u'android',))
-        ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
         data = {
             'happy': 0,
             'description': u'Video plays backwards :(',
             'url': u'http://mozilla.org/'
         }
-        r1 = self.client.post(url, data, HTTP_USER_AGENT=ua)
-        self.assertRedirects(r1, reverse('thanks'))
+        r = self.client.post(url, data=data, follow=True)
         # The below tests whether the feedback view function
         # register_feedback_config() is working as it should
-        r2 = self.client.get(r1.url)
-        assert template_used(r2, 'feedback/android_thanks.html')
+        assert template_used(r, 'feedback/android_thanks.html')
 
     def test_description_values(self):
         desc = u'Terima kasih \U0001f60a'

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -193,6 +193,29 @@ class TestFeedback(TestCase):
         r = self.client.get(url, HTTP_USER_AGENT=ua)
         assert template_used(r, 'feedback/fxos_feedback.html')
 
+    def test_android_view(self):
+        """Android returns correct view"""
+        # Specifying fxos as the product in the url
+        url = reverse('feedback', args=(u'android',))
+        r = self.client.get(url)
+        assert template_used(r, 'feedback/android_feedback.html')
+
+    def test_android_view_redirects_to_android_thanks(self):
+        """Sad feedback in Android redirects to proper thanks template"""
+        url = reverse('feedback', args=(u'android',))
+        ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
+        data = {
+            'happy': 0,
+            'description': u'Video plays backwards :(',
+            'url': u'http://mozilla.org/'
+        }
+        r1 = self.client.post(url, data, HTTP_USER_AGENT=ua)
+        self.assertRedirects(r1, reverse('thanks'))
+        # The below tests whether the feedback view function
+        # register_feedback_config() is working as it should
+        r2 = self.client.get(r1.url)
+        assert template_used(r2, 'feedback/android_thanks.html')
+
     def test_description_values(self):
         desc = u'Terima kasih \U0001f60a'
         url = reverse('feedback', args=(u'firefox',))

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -327,6 +327,26 @@ def generic_feedback(request, locale=None, product=None, version=None,
     })
 
 
+@register_feedback_config('android', 'feedback/android_thanks.html')
+@csrf_protect
+def android_feedback(request, locale=None, product=None, version=None,
+                     channel=None):
+    """Generic feedback form for desktop and mobile"""
+    form = ResponseForm()
+
+    if request.method == 'POST':
+        return _handle_feedback_post(request, locale, product,
+                                     version, channel)
+
+    return render(request, 'feedback/android_feedback.html', {
+        'form': form,
+        'product': product,
+        'version': version,
+        'channel': channel,
+        'TRUNCATE_LENGTH': TRUNCATE_LENGTH,
+    })
+
+
 @register_feedback_config('fxos', None)
 @csrf_exempt
 def firefox_os_stable_feedback(request, locale=None, product=None,

--- a/fjord/settings/base.py
+++ b/fjord/settings/base.py
@@ -468,6 +468,14 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'feedback.css'
     },
+    'android-feedback': {
+        'source_filenames': (
+            'css/lib/normalize.css',
+            'css/feedback.less',
+            'css/android-feedback.less',
+        ),
+        'output_filename': 'android-feedback.css'
+    },
 }
 
 PIPELINE_JS = {
@@ -545,6 +553,19 @@ PIPELINE_JS = {
             'js/ga.js',
         ),
         'output_filename': 'fxos_feedback.js'
+    },
+    'android_feedback': {
+        'source_filenames': (
+            'js/lib/jquery.min.js',
+            'js/fjord_utils.js',
+            'js/remote.js',
+            'js/cards.js',
+            'js/common_feedback.js',
+            'js/generic_feedback.js',
+            'js/android_feedback.js',
+            'js/ga.js',
+        ),
+        'output_filename': 'android_feedback.js'
     },
 }
 

--- a/smoketests/pages/android_feedback_form.py
+++ b/smoketests/pages/android_feedback_form.py
@@ -11,19 +11,16 @@ from pages.feedback import FeedbackPage
 class AndroidFeedbackFormPage(FeedbackPage):
     _page_title = 'Firefox Feedback :: Firefox Input'
 
-    def go_to_feedback_page(self,
-                            version="",
-                            channel="",
-                            last_visited="",
-                            in_device=False):
+    def go_to_feedback_page(self, version='', channel='',
+                            last_visited='', in_device=False):
         url = self.base_url + '/feedback/android'
         params = []
 
         if version:
-            url = '%s/%s' % (url, version)
+            url = url + '/' + version
 
         if channel:
-            url = '%s/%s' % (url, channel)
+            url = url + '/' + channel
 
         if in_device:
             params.append('utm_source=feedback-prompt')
@@ -32,22 +29,21 @@ class AndroidFeedbackFormPage(FeedbackPage):
             params.append('url=%s' % (last_visited))
 
         if len(params) > 0:
-            url = '%s/?%s' % (url, '&'.join(params))
-
-        print('Requesting url: %s' % url)
+            params = '&'.join(params)
+            url = url + '/?' + params
 
         self.selenium.get(url)
         self.is_the_current_page
 
     # Intro card
-    _happy_button_locator = (By.CSS_SELECTOR, '#intro #happy-button')
-    _sad_button_locator = (By.CSS_SELECTOR, '#intro #sad-button')
+    _happy_button_locator = (By.ID, 'happy-button')
+    _sad_button_locator = (By.ID, 'sad-button')
 
     def click_happy_feedback(self):
         self.selenium.find_element(*self._happy_button_locator).click()
 
     # Happy thanks
-    _playstore_locator = (By.CSS_SELECTOR, '#play-store')
+    _playstore_locator = (By.ID, 'play-store')
 
     @property
     def playstore_link_is_http_release(self):
@@ -72,8 +68,8 @@ class AndroidFeedbackFormPage(FeedbackPage):
 
     @property
     def on_device_links_present(self):
-        if (self.is_element_visible_no_wait((By.CSS_SELECTOR, '#maybe-later')) and
-                self.is_element_visible_no_wait((By.CSS_SELECTOR, '#no-thanks'))):
+        if (self.is_element_visible_no_wait((By.ID, 'maybe-later')) and
+                self.is_element_visible_no_wait((By.ID, 'no-thanks'))):
                     return True
 
         return False
@@ -83,30 +79,14 @@ class AndroidFeedbackFormPage(FeedbackPage):
         self.wait_for(self._moreinfo_text_locator)
 
     # Moreinfo card
-    _moreinfo_text_locator = (By.CSS_SELECTOR, '#moreinfo #description')
+    _moreinfo_text_locator = (By.ID, 'description')
     _url_locator = (By.ID, 'id_url')
-    _submit_locator = (By.CSS_SELECTOR, '#moreinfo #form-submit-btn')
+    _submit_locator = (By.ID, 'form-submit-btn')
     _checkbox_locator = (By.ID, 'last-checkbox')
-
-    def set_description_execute_script(self, text):
-        """Sets the value of the description textarea using execute_script
-
-        :arg text: The text to set
-
-        We use ``execute_script`` here because sending keys one at a time
-        takes a crazy amount of time for texts > 200 characters.
-
-        """
-        text = text.replace("'", "\\'").replace('"', '\\"')
-        self.selenium.execute_script("$('#description').val('" + text + "')")
 
     def set_description(self, text):
         desc = self.selenium.find_element(*self._moreinfo_text_locator)
         desc.clear()
-        desc.send_keys(text)
-
-    def update_description(self, text):
-        desc = self.selenium.find_element(*self._moreinfo_text_locator)
         desc.send_keys(text)
 
     @property
@@ -133,17 +113,17 @@ class AndroidFeedbackFormPage(FeedbackPage):
     def uncheck_url(self):
         self.selenium.find_element(*self._checkbox_locator).click()
 
-    _thanks_locator = (By.CSS_SELECTOR, '#thanks')
+    _thanks_locator = (By.ID, 'thanks')
 
     def submit(self, expect_success=True):
         self.selenium.find_element(*self._submit_locator).click()
         if expect_success:
-            self.wait_for((By.CSS_SELECTOR, '#thanks'))
+            self.wait_for((By.ID, 'thanks'))
 
     @property
     def current_card(self):
         for card in ('intro', 'moreinfo', 'thanks'):
-            if self.is_element_visible_no_wait((By.CSS_SELECTOR, '#' + card)):
+            if self.is_element_visible_no_wait((By.ID, card)):
                 return card
 
     @property

--- a/smoketests/pages/android_feedback_form.py
+++ b/smoketests/pages/android_feedback_form.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from pages.feedback import FeedbackPage
+
+
+class AndroidFeedbackFormPage(FeedbackPage):
+    _page_title = 'Firefox Feedback :: Firefox Input'
+
+    def go_to_feedback_page(self,
+                            version="",
+                            channel="",
+                            last_visited="",
+                            in_device=False):
+        url = self.base_url + '/feedback/android'
+        params = []
+
+        if version:
+            url = '%s/%s' % (url, version)
+
+        if channel:
+            url = '%s/%s' % (url, channel)
+
+        if in_device:
+            params.append('utm_source=feedback-prompt')
+
+        if last_visited:
+            params.append('url=%s' % (last_visited))
+
+        if len(params) > 0:
+            url = '%s/?%s' % (url, '&'.join(params))
+
+        print('Requesting url: %s' % url)
+
+        self.selenium.get(url)
+        self.is_the_current_page
+
+    # Intro card
+    _happy_button_locator = (By.CSS_SELECTOR, '#intro #happy-button')
+    _sad_button_locator = (By.CSS_SELECTOR, '#intro #sad-button')
+
+    def click_happy_feedback(self):
+        self.selenium.find_element(*self._happy_button_locator).click()
+
+    # Happy thanks
+    _playstore_locator = (By.CSS_SELECTOR, '#play-store')
+
+    @property
+    def playstore_link_is_http_release(self):
+        href = self.selenium.find_element(
+            *self._playstore_locator
+        ).get_attribute('href')
+        return href == 'https://play.google.com/store/apps/details?id=org.mozilla.firefox#details-reviews'
+
+    @property
+    def playstore_link_is_intent_release(self):
+        href = self.selenium.find_element(
+            *self._playstore_locator
+        ).get_attribute('href')
+        return href == 'market://details?id=org.mozilla.firefox'
+
+    @property
+    def playstore_link_is_intent_beta(self):
+        href = self.selenium.find_element(
+            *self._playstore_locator
+        ).get_attribute('href')
+        return href == 'market://details?id=org.mozilla.firefox_beta'
+
+    @property
+    def on_device_links_present(self):
+        if (self.is_element_visible_no_wait((By.CSS_SELECTOR, '#maybe-later')) and
+                self.is_element_visible_no_wait((By.CSS_SELECTOR, '#no-thanks'))):
+                    return True
+
+        return False
+
+    def click_sad_feedback(self):
+        self.selenium.find_element(*self._sad_button_locator).click()
+        self.wait_for(self._moreinfo_text_locator)
+
+    # Moreinfo card
+    _moreinfo_text_locator = (By.CSS_SELECTOR, '#moreinfo #description')
+    _url_locator = (By.ID, 'id_url')
+    _submit_locator = (By.CSS_SELECTOR, '#moreinfo #form-submit-btn')
+    _checkbox_locator = (By.ID, 'last-checkbox')
+
+    def set_description_execute_script(self, text):
+        """Sets the value of the description textarea using execute_script
+
+        :arg text: The text to set
+
+        We use ``execute_script`` here because sending keys one at a time
+        takes a crazy amount of time for texts > 200 characters.
+
+        """
+        text = text.replace("'", "\\'").replace('"', '\\"')
+        self.selenium.execute_script("$('#description').val('" + text + "')")
+
+    def set_description(self, text):
+        desc = self.selenium.find_element(*self._moreinfo_text_locator)
+        desc.clear()
+        desc.send_keys(text)
+
+    def update_description(self, text):
+        desc = self.selenium.find_element(*self._moreinfo_text_locator)
+        desc.send_keys(text)
+
+    @property
+    def is_submit_enabled(self):
+        return self.selenium.find_element(*self._submit_locator).is_enabled()
+
+    @property
+    def support_link_present(self):
+        return self.is_element_visible_no_wait(
+            (By.CSS_SELECTOR, '.footer.sad .help-section a')
+        )
+
+    def url_prepopulated(self):
+        contents = self.selenium.find_element(
+            *self._url_locator
+        ).get_attribute("value")
+        return contents
+
+    def set_url(self, text):
+        url = self.selenium.find_element(*self._url_locator)
+        url.clear()
+        url.send_keys(text)
+
+    def uncheck_url(self):
+        self.selenium.find_element(*self._checkbox_locator).click()
+
+    _thanks_locator = (By.CSS_SELECTOR, '#thanks')
+
+    def submit(self, expect_success=True):
+        self.selenium.find_element(*self._submit_locator).click()
+        if expect_success:
+            self.wait_for((By.CSS_SELECTOR, '#thanks'))
+
+    @property
+    def current_card(self):
+        for card in ('intro', 'moreinfo', 'thanks'):
+            if self.is_element_visible_no_wait((By.CSS_SELECTOR, '#' + card)):
+                return card
+
+    @property
+    def current_sentiment(self):
+        for sentiment in ('happy', 'sad'):
+            if self.is_element_visible_no_wait((By.CSS_SELECTOR, '#moreinfo .' + sentiment)):
+                return sentiment

--- a/smoketests/tests/android/test_android_feedback.py
+++ b/smoketests/tests/android/test_android_feedback.py
@@ -1,0 +1,102 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+import pytest
+from tests import TestCase
+from pages.dashboard import DashboardPage
+from pages.android_feedback_form import AndroidFeedbackFormPage
+
+
+class TestFeedback(TestCase):
+
+    @pytest.mark.nondestructive
+    def test_on_device_links(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        version = "44"
+        channel = "beta"
+        last_url = "http://mozilla.com"
+        on_device = True
+
+        # 1. Go to feedback page on device, look for links
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
+        assert feedback_pg.on_device_links_present
+
+        # 2. Go to feedback page on desktop, look for links
+        feedback_pg.go_to_feedback_page(version, channel, last_url, False)
+        assert feedback_pg.on_device_links_present is False
+
+    @pytest.mark.nondestructive
+    def test_submit_happy_feedback(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        version = "44"
+        channel = "beta"
+        last_url = "http://mozilla.com"
+        on_device = True
+
+        # 1. Go to feedback page and click happy
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
+        feedback_pg.click_happy_feedback()
+        assert feedback_pg.current_sentiment == 'happy'
+
+        # 2. Go to happy page in beta, on device
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
+        feedback_pg.click_happy_feedback()
+        assert feedback_pg.playstore_link_is_intent_beta
+
+        # 3. Go to happy page in release channel, on device
+        feedback_pg.go_to_feedback_page(version,
+                                        "release",
+                                        last_url,
+                                        on_device)
+        feedback_pg.click_happy_feedback()
+        assert feedback_pg.playstore_link_is_intent_release
+
+        # 4. Go to happy page in release channel, on desktop
+        feedback_pg.go_to_feedback_page(version, "release", last_url, False)
+        feedback_pg.click_happy_feedback()
+        assert feedback_pg.playstore_link_is_http_release
+
+    @pytest.mark.nondestructive
+    def test_submit_sad_feedback(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        timestamp = str(time.time())
+        desc = 'input-tests testing sad android feedback ' + timestamp
+        version = "44"
+        channel = "beta"
+        last_url = "http://mozilla.com"
+        on_device = True
+
+        # 1. Go to feedback page and click sad
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
+        feedback_pg.click_sad_feedback()
+        assert feedback_pg.current_sentiment == 'sad'
+
+        # 2. Look for Support link
+        assert feedback_pg.support_link_present
+
+        # 3. Look for URL we passed
+        assert feedback_pg.url_prepopulated() == last_url
+
+        # 4. don't send the URL
+        feedback_pg.uncheck_url()
+
+        # 5. fill in description
+        feedback_pg.set_description(desc)
+
+        # 6. submit
+        feedback_pg.submit(expect_success=True)
+        self.take_a_breather()
+        assert feedback_pg.current_card == 'thanks'
+
+        # 7. verify
+        dashboard_pg = DashboardPage(mozwebqa)
+        dashboard_pg.go_to_dashboard_page()
+        dashboard_pg.search_for(desc)
+        resp = dashboard_pg.messages[0]
+        assert resp.type.strip() == 'Sad'
+        assert resp.body.strip() == desc.strip()
+        assert resp.locale.strip() == 'English (US)'
+        # we didn't send the url, it should not be here
+        assert resp.site.strip() != last_url

--- a/smoketests/tests/android/test_android_feedback.py
+++ b/smoketests/tests/android/test_android_feedback.py
@@ -19,12 +19,20 @@ class TestFeedback(TestCase):
         last_url = "http://mozilla.com"
         on_device = True
 
-        # 1. Go to feedback page on device, look for links
+        # Go to feedback page on device, look for links
         feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
         assert feedback_pg.on_device_links_present
 
-        # 2. Go to feedback page on desktop, look for links
-        feedback_pg.go_to_feedback_page(version, channel, last_url, False)
+    @pytest.mark.nondestructive
+    def test_on_desktop_links(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        version = "44"
+        channel = "beta"
+        last_url = "http://mozilla.com"
+        on_device = False
+
+        # Go to feedback page on desktop, look for links
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
         assert feedback_pg.on_device_links_present is False
 
     @pytest.mark.nondestructive
@@ -35,30 +43,50 @@ class TestFeedback(TestCase):
         last_url = "http://mozilla.com"
         on_device = True
 
-        # 1. Go to feedback page and click happy
+        # Go to feedback page and click happy
         feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
         feedback_pg.click_happy_feedback()
         assert feedback_pg.current_sentiment == 'happy'
 
-        # 2. Go to happy page in beta, on device
+    @pytest.mark.nondestructive
+    def test_submit_happy_feedback_in_beta(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        version = "44"
+        channel = "beta"
+        last_url = "http://mozilla.com"
+        on_device = True
+
+        # Go to happy page in beta, on device
         feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
         feedback_pg.click_happy_feedback()
         assert feedback_pg.playstore_link_is_intent_beta
 
-        # 3. Go to happy page in release channel, on device
-        feedback_pg.go_to_feedback_page(version,
-                                        "release",
-                                        last_url,
-                                        on_device)
+    @pytest.mark.nondestructive
+    def test_submit_happy_feedback_in_release_on_device(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        version = "44"
+        channel = "release"
+        last_url = "http://mozilla.com"
+        on_device = True
+
+        # Go to happy page in release channel, on device
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
         feedback_pg.click_happy_feedback()
         assert feedback_pg.playstore_link_is_intent_release
 
-        # 4. Go to happy page in release channel, on desktop
-        feedback_pg.go_to_feedback_page(version, "release", last_url, False)
+    @pytest.mark.nondestructive
+    def test_submit_happy_feedback_in_release_on_desktop(self, mozwebqa):
+        feedback_pg = AndroidFeedbackFormPage(mozwebqa)
+        version = "44"
+        channel = "release"
+        last_url = "http://mozilla.com"
+        on_device = False
+
+        # Go to happy page in release channel, on desktop
+        feedback_pg.go_to_feedback_page(version, channel, last_url, on_device)
         feedback_pg.click_happy_feedback()
         assert feedback_pg.playstore_link_is_http_release
 
-    @pytest.mark.nondestructive
     def test_submit_sad_feedback(self, mozwebqa):
         feedback_pg = AndroidFeedbackFormPage(mozwebqa)
         timestamp = str(time.time())


### PR DESCRIPTION
This PR does 2 things. 
1. Includes front-end integration of styles from about:feedback in FxA. Still missing links and integration with "later" and "never". Check the SVG hotness.
2. Addresses the concerns from #722. Specifically...

* doesn't overload PRODUCT_OVERRIDE
* doesn't customize /thanks
* doesn't save happy feedback