### PR TITLE
[bug 1235423] Refactor feedback_router

### DIFF
--- a/fjord/base/jinja2/base.html
+++ b/fjord/base/jinja2/base.html
@@ -48,7 +48,7 @@
 
           <ul>
             <li><a class="dashboard" href="{{ url('dashboard') }}"><span>{{ _('Dashboard') }}</span></a></li>
-            <li><a class="feedback" href="{{ url('feedback') }}"><span>{{ _('Give Feedback') }}</span></a></li>
+            <li><a class="feedback" href="{{ url('picker') }}"><span>{{ _('Give Feedback') }}</span></a></li>
             {% if user.is_authenticated() and user.has_perm('analytics.can_view_dashboard') %}
               <li><a class="adashboard" href="{{ url('analytics_dashboard') }}"><span>{{ _('Analytics') }}</span></a></li>
             {% endif %}

--- a/fjord/base/tests/test_utils.py
+++ b/fjord/base/tests/test_utils.py
@@ -180,7 +180,7 @@ class TestActualIPPlusContext(TestCase):
             lambda req: req.POST.get('description', 'no description')
         )
 
-        url = reverse('feedback')
+        url = reverse('picker')
         factory = RequestFactory(HTTP_X_CLUSTER_CLIENT_IP='192.168.100.101')
 
         # create a request with this as the description
@@ -214,7 +214,7 @@ class TestActualIPPlusContext(TestCase):
             lambda req: req.POST.get('description', 'no description')
         )
 
-        url = reverse('feedback')
+        url = reverse('picker')
         factory = RequestFactory(
             HTTP_X_CLUSTER_CLIENT_IP='0000:0000:0000:0000:0000:0000:0000:0000')
 

--- a/fjord/feedback/jinja2/feedback/fxos_feedback.html
+++ b/fjord/feedback/jinja2/feedback/fxos_feedback.html
@@ -81,7 +81,7 @@
 
           <aside>
             <div id="back-to-picker">
-              {% trans product=product.display_name, url=url('feedback') + '?' + request.GET.urlencode() %}
+              {% trans product=product.display_name, url=url('picker') + '?' + request.GET.urlencode() %}
                 Is {{product}} not the product you want to give feedback on?<br />
                 <a href="{{url}}">Pick a different product</a>.
               {% endtrans %}

--- a/fjord/feedback/jinja2/feedback/generic_feedback.html
+++ b/fjord/feedback/jinja2/feedback/generic_feedback.html
@@ -83,7 +83,7 @@
 
             <aside>
               <div id="back-to-picker">
-                {% trans product=product.display_name, url=url('feedback') + '?' + request.GET.urlencode() %}
+                {% trans product=product.display_name, url=url('picker') + '?' + request.GET.urlencode() %}
                   Is {{product}} not the product you want to give feedback on?<br />
                   <a href="{{url}}">Pick a different product</a>.
                 {% endtrans %}

--- a/fjord/feedback/jinja2/feedback/picker.html
+++ b/fjord/feedback/jinja2/feedback/picker.html
@@ -39,7 +39,7 @@
               <ul id="product-cards" class="card-grid cf">
                 {% for prod in products %}
                   <li>
-                    <a class="cf" href="{{ url('feedback', product=prod.slug) }}?{{ request.GET.urlencode() }}">
+                    <a class="cf" href="{{ url('feedback', product_slug=prod.slug) }}?{{ request.GET.urlencode() }}">
                       <img class="logo-sprite" src="{{ settings.STATIC_URL }}img/{{ prod.image_file or 'blank.png' }}" alt="" />
                       <span class="title">{{ prod.display_name }}</span>
                       <span class="description">{{ prod.display_description }}</span>

--- a/fjord/feedback/tests/test_views.py
+++ b/fjord/feedback/tests/test_views.py
@@ -21,11 +21,11 @@ class TestRedirectFeedback(TestCase):
 
     def test_happy_redirect(self):
         r = self.client.get(reverse('happy-redirect'))
-        self.assertRedirects(r, reverse('feedback') + '?happy=1')
+        self.assertRedirects(r, reverse('picker') + '?happy=1')
 
     def test_sad_redirect(self):
         r = self.client.get(reverse('sad-redirect'))
-        self.assertRedirects(r, reverse('feedback') + '?happy=0')
+        self.assertRedirects(r, reverse('picker') + '?happy=0')
 
 
 class TestFeedback(TestCase):
@@ -176,12 +176,6 @@ class TestFeedback(TestCase):
 
     def test_firefox_os_view(self):
         """Firefox OS returns correct view"""
-        # Firefox OS is the user agent
-        url = reverse('feedback')
-        ua = 'Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0'
-        r = self.client.get(url, HTTP_USER_AGENT=ua)
-        assert template_used(r, 'feedback/fxos_feedback.html')
-
         # Specifying fxos as the product in the url
         url = reverse('feedback', args=(u'fxos',))
         r = self.client.get(url)
@@ -962,6 +956,10 @@ class TestFeedback(TestCase):
 class TestDeprecatedAndroidFeedback(TestCase):
     client_class = LocalizingClient
 
+    # Note: We hardcode `/feedback/` because that's exactly where Firefox
+    # for Android is sending data.
+    url = '/feedback/'
+
     def test_deprecated_firefox_for_android_feedback_works(self):
         """Verify firefox for android can post feedback"""
         data = {
@@ -975,7 +973,7 @@ class TestDeprecatedAndroidFeedback(TestCase):
 
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
-        r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
+        r = self.client.post(self.url, data, HTTP_USER_AGENT=ua)
         assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.happy is True
@@ -1004,7 +1002,7 @@ class TestDeprecatedAndroidFeedback(TestCase):
 
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
-        r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
+        r = self.client.post(self.url, data, HTTP_USER_AGENT=ua)
         assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.happy is False
@@ -1030,7 +1028,7 @@ class TestDeprecatedAndroidFeedback(TestCase):
 
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
-        r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
+        r = self.client.post(self.url, data, HTTP_USER_AGENT=ua)
         assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.happy is False
@@ -1054,7 +1052,7 @@ class TestDeprecatedAndroidFeedback(TestCase):
 
         ua = 'Mozilla/5.0 (Android; Tablet; rv:24.0) Gecko/24.0 Firefox/24.0'
 
-        r = self.client.post(reverse('feedback'), data, HTTP_USER_AGENT=ua)
+        r = self.client.post(self.url, data, HTTP_USER_AGENT=ua)
         assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.happy is True
@@ -1080,8 +1078,7 @@ class TestDeprecatedAndroidFeedback(TestCase):
               'Build/IMM76) AppleWebKit/534.30 (KHTML, like Gecko) '
               'Version/4.0 Safari/534.30')
 
-        r = self.client.post(reverse('feedback'), data,
-                             HTTP_USER_AGENT=ua)
+        r = self.client.post(self.url, data, HTTP_USER_AGENT=ua)
         assert r.status_code == 302
         feedback = models.Response.objects.latest(field_name='id')
         assert feedback.browser == u''
@@ -1105,7 +1102,7 @@ class TestPicker(TestCase):
         models.Product.objects.all().delete()
 
     def test_picker_no_products(self):
-        resp = self.client.get(reverse('feedback'))
+        resp = self.client.get(reverse('picker'))
 
         assert resp.status_code == 200
         assert template_used(resp, 'feedback/picker.html')
@@ -1117,7 +1114,7 @@ class TestPicker(TestCase):
 
         cache.clear()
 
-        resp = self.client.get(reverse('feedback'))
+        resp = self.client.get(reverse('picker'))
 
         assert resp.status_code == 200
 
@@ -1134,7 +1131,7 @@ class TestPicker(TestCase):
 
         cache.clear()
 
-        resp = self.client.get(reverse('feedback'))
+        resp = self.client.get(reverse('picker'))
 
         assert resp.status_code == 200
 
@@ -1154,7 +1151,7 @@ class TestPicker(TestCase):
 
         cache.clear()
 
-        resp = self.client.get(reverse('feedback'))
+        resp = self.client.get(reverse('picker'))
 
         assert resp.status_code == 200
 

--- a/fjord/feedback/urls.py
+++ b/fjord/feedback/urls.py
@@ -17,7 +17,7 @@ urlpatterns = patterns(
         r'/?$',
         'feedback_router', name='feedback'),
 
-    url(r'^thanks/?$', 'thanks', name='thanks'),
+    url(r'^thanks/?$', 'thanks_view', name='thanks'),
 
     # These are redirects for backwards compatibility with old urls
     # used for Firefox feedback

--- a/fjord/feedback/urls.py
+++ b/fjord/feedback/urls.py
@@ -6,11 +6,14 @@ from fjord.feedback import api_views
 urlpatterns = patterns(
     'fjord.feedback.views',
 
+    # feedback/
+    url(r'^feedback/?$', 'picker_view', name='picker'),
+
     # feedback/%PRODUCT%/%VERSION%/%CHANNEL%
     url(r'^feedback'
-        r'(?:/(?P<product>[^/]+)'
+        r'/(?P<product_slug>[^/]+)'
         r'(?:/(?P<version>[^/]+)'
-        r'(?:/(?P<channel>[^/]+))?)?)?'
+        r'(?:/(?P<channel>[^/]+))?)?'
         r'/?$',
         'feedback_router', name='feedback'),
 

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -28,11 +28,25 @@ from fjord.feedback.config import TRUNCATE_LENGTH
 from fjord.suggest.utils import get_suggestions
 
 
+# Feedback configurations for products. If it's not in here, you'll get
+# the generic one.
+#
+# product_slug -> {'view': view_fun, 'thanks_template': template_path}
 PRODUCT_CONFIG = {}
 
 
 def register_feedback_config(product_slug, thanks_template):
-    """Registers a product config"""
+    """Registers a product config
+
+    Example::
+
+        @register_feedback_config('android', 'feedback/android_thanks.html')
+        @csrf_protect
+        def android_feedback(request, locale=None, product=None, version=None,
+                             channel=None):
+            # blah blah blah
+
+    """
     def _register(fun):
         PRODUCT_CONFIG[product_slug] = {
             'view': fun,

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -349,13 +349,14 @@ def firefox_os_stable_feedback(request, locale=None, product=None,
 def fix_oldandroid(request):
     """Fixes old android requests
 
-    Old versions of Firefox for Android have a feedback form built in that
-    generates POSTS directly to Input and is always sad or ideas. The POST data
-    matches what the old Input used to do. The new Input doesn't have a
-    ``_type`` field and doesn't have Idea feedback, so we switch it so that all
-    Idea feedback is Sad and tag it with a source.
+    Old versions of Firefox for Android have an in-product feedback form that
+    generates POSTS directly to Input and is always "sad" or "idea". The POST
+    data matches what the old Input used to do. The new Input doesn't have a
+    ``_type`` field and doesn't have "idea" feedback, so we switch "idea" to be
+    "sad", put it in the right field and then additionally tag the feedback
+    with a source if it doesn't already have one.
 
-    FIXME - measure usage of this and nix it when we can. See bug #964292.
+    FIXME: Measure usage of this and nix it when we can. See bug #964292.
 
     :arg request: a Request object
 

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -6,7 +6,6 @@ from django.shortcuts import render
 from django.utils import translation
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
-from django.views.decorators.http import require_POST
 
 from statsd.defaults.django import statsd
 import waffle
@@ -31,12 +30,12 @@ from fjord.suggest.utils import get_suggestions
 
 def happy_redirect(request):
     """Support older redirects from Input v1 era"""
-    return HttpResponseRedirect(reverse('feedback') + '?happy=1')
+    return HttpResponseRedirect(reverse('picker') + '?happy=1')
 
 
 def sad_redirect(request):
     """Support older redirects from Input v1 era"""
-    return HttpResponseRedirect(reverse('feedback') + '?happy=0')
+    return HttpResponseRedirect(reverse('picker') + '?happy=0')
 
 
 def thanks(request):
@@ -310,10 +309,8 @@ def firefox_os_stable_feedback(request, locale=None, product=None,
     })
 
 
-@csrf_exempt
-@require_POST
-def android_about_feedback(request, locale=None):
-    """A view specifically for old Firefox for Android
+def fix_oldandroid(request):
+    """Fixes old android requests
 
     Old versions of Firefox for Android have a feedback form built in that
     generates POSTS directly to Input and is always sad or ideas. The POST data
@@ -321,8 +318,11 @@ def android_about_feedback(request, locale=None):
     ``_type`` field and doesn't have Idea feedback, so we switch it so that all
     Idea feedback is Sad and tag it with a source.
 
-    FIXME - measure usage of this and nix it when we can. See bug
-    #964292.
+    FIXME - measure usage of this and nix it when we can. See bug #964292.
+
+    :arg request: a Request object
+
+    :returns: a fixed Request object
 
     """
     # Firefox for Android only sends up sad and idea responses, but it
@@ -346,16 +346,9 @@ def android_about_feedback(request, locale=None):
         request.GET = request.GET.copy()
         request.GET['utm_source'] = 'oldfennec-in-product'
 
-    # Note: product, version and channel are always None in this view
-    # since this is to handle backwards-compatibility. So we don't
-    # bother passing them along.
+    statsd.incr('feedback.oldandroid')
 
-    # We always return Thanks! now and ignore errors.
-    return _handle_feedback_post(request, locale)
-
-
-PRODUCT_OVERRIDE = {
-}
+    return request
 
 
 def persist_feedbackdev(fun):
@@ -373,23 +366,27 @@ def persist_feedbackdev(fun):
     return _persist_feedbackdev
 
 
+@csrf_exempt  # Need for oldandroid feedback POST handling
+def picker_view(request):
+    """View showing the product picker"""
+    # The old Firefox for Android would POST form data to /feedback/. If we see
+    # that, we fix the request up and then handle it as a feedback post.
+    if '_type' in request.POST:
+        request = fix_oldandroid(request)
+        return _handle_feedback_post(request, request.locale)
+
+    picker_products = models.Product.objects.on_picker()
+    return render(request, 'feedback/picker.html', {
+        'products': picker_products
+    })
+
+
 @csrf_exempt
 @never_cache
 @persist_feedbackdev
-def feedback_router(request, product=None, version=None, channel=None,
+def feedback_router(request, product_slug=None, version=None, channel=None,
                     *args, **kwargs):
-    """Determine a view to use, and call it.
-
-    If product is given, reference `product_routes` to look up a view.
-    If `product` is not passed, or isn't found in `product_routes`,
-    asssume the user is either a stable desktop Firefox or a stable
-    mobile Firefox based on the parsed UA, and serve them the
-    appropriate page. This is to handle the old formname way of doing
-    things. At some point P, we should measure usage of the old
-    formnames and deprecate them.
-
-    This also handles backwards-compatability with the old Firefox for
-    Android form which can't have a CSRF token.
+    """Figure out which flow to use for a product and route accordingly
 
     .. Note::
 
@@ -404,70 +401,36 @@ def feedback_router(request, product=None, version=None, channel=None,
           change this!
 
     """
-    view = None
-
+    # The old Firefox for Android would POST form data to /feedback/. If we see
+    # that, we fix the request up and then handle it as a feedback post.
     if '_type' in request.POST:
-        # Checks to see if `_type` is in the POST data and if so this
-        # is coming from Firefox for Android which doesn't know
-        # anything about csrf tokens. If that's the case, we send it
-        # to a view specifically for FfA Otherwise we pass it to one
-        # of the normal views, which enforces CSRF. Also, nix the
-        # product just in case we're crossing the streams and
-        # confusing new-style product urls with old-style backwards
-        # compatability for the Android form.
-        #
-        # FIXME: Remove this hairbrained monstrosity when we don't need to
-        # support the method that Firefox for Android currently uses to
-        # post feedback which worked with the old input.mozilla.org.
-        view = android_about_feedback
-        product = None
+        request = fix_oldandroid(request)
+        return _handle_feedback_post(request, request.locale)
 
-        # This lets us measure how often this section of code kicks
-        # off and thus how often old android stuff is happening. When
-        # we're not seeing this anymore, we can nix all the old
-        # android stuff.
-        statsd.incr('feedback.oldandroid')
-
-        return android_about_feedback(request, request.locale)
+    view_fun = generic_feedback
 
     # FIXME - validate these better
-    product = smart_str(product, fallback=None)
+    product_slug = smart_str(product_slug, fallback=None)
     version = smart_str(version)
     channel = smart_str(channel).lower()
 
-    if product == 'fxos' or request.BROWSER.browser == 'Firefox OS':
-        # Firefox OS gets shunted to a different form which has
-        # different Firefox OS specific questions.
-        view = firefox_os_stable_feedback
-        product = 'fxos'
+    if product_slug == 'fxos':
+        # Firefox OS has their form which uses the API.
+        view_fun = firefox_os_stable_feedback
+        product_slug = 'fxos'
 
-    elif product in PRODUCT_OVERRIDE:
-        # If the product is really a form name, we use that
-        # form specifically.
-        view = PRODUCT_OVERRIDE[product]
-        product = None
+    # Add new product_slug -> form stuff here.
 
-    elif (product is None
-          or product not in models.Product.objects.get_product_map()):
+    if ((product_slug is not None
+         and product_slug in models.Product.objects.get_product_map())):
 
-        picker_products = models.Product.objects.on_picker()
-        return render(request, 'feedback/picker.html', {
-            'products': picker_products
-        })
+        # Convert the product_slug to a product.
+        product = models.Product.objects.from_slug(product_slug)
 
-    product = models.Product.objects.from_slug(product)
+        # Send them on their way
+        return view_fun(request, request.locale, product, version, channel,
+                        *args, **kwargs)
 
-    if view is None:
-        view = generic_feedback
-
-    return view(request, request.locale, product, version, channel,
-                *args, **kwargs)
-
-
-def cyoa(request):
-    template = 'feedback/picker.html'
-
-    products = models.Product.objects.all()
-    return render(request, template, {
-        'products': products
-    })
+    # At this point, if we don't know the product or it doesn't exist, redirect
+    # them to the picker.
+    return HttpResponseRedirect(reverse('picker'))


### PR DESCRIPTION
This splits the picker view from the feedback_router code. Having said
that, the oldandroid code makes that continue to look a bit goofy.

This drops the requirement that we *only* show the Firefox OS form to
users of Firefox OS. With these code changes, if they got to
/feedback/, they'll now go to the picker. We don't get a lot of
Firefox OS feedback. As of 1.3, they have an in-product form that uses
the API anyhow.

This gets rid of the PRODUCT_OVERRIDES scaffolding which we haven't
used in ages and has very much overstayed its welcome.

The end result is a feedback_router that's a little more
straight-forward.