### PR TITLE
[bug 1236581] Fix Thank You view

### DIFF
--- a/fjord/feedback/jinja2/feedback/thanks.html
+++ b/fjord/feedback/jinja2/feedback/thanks.html
@@ -22,7 +22,7 @@
       <div class="card thanks">
         <section>
           <div class="part">
-            {% trans product=product %}
+            {% trans product=product.display_name %}
               Your feedback will be used to create a better experience in
               future releases of {{ product }}.
             {% endtrans %}
@@ -73,7 +73,7 @@
           <div class="part">
             <h2>{{ _('Contribute to Mozilla.') }}</h2>
             <p>
-              {% trans url='http://mozilla.org/contribute/', product=product %}
+              {% trans url='http://mozilla.org/contribute/', product=product.display_name %}
                 Learn how you can <a href="{{ url }}">make {{ product }} and Mozilla better</a>.
               {% endtrans %}
             </p>
@@ -81,7 +81,7 @@
 
           <div class="part" id="thanks-news">
             <h2>
-              {% trans product=product %}
+              {% trans product=product.display_name %}
                 Find the latest news about {{ product }}.
               {% endtrans %}
             </h2>

--- a/fjord/feedback/views.py
+++ b/fjord/feedback/views.py
@@ -22,7 +22,7 @@ from fjord.base.utils import (
 from fjord.feedback import config
 from fjord.feedback import models
 from fjord.feedback.forms import ResponseForm
-from fjord.feedback.models import Response
+from fjord.feedback.models import Product, Response
 from fjord.feedback.utils import clean_url
 from fjord.feedback.config import TRUNCATE_LENGTH
 from fjord.suggest.utils import get_suggestions
@@ -74,8 +74,6 @@ def sad_redirect(request):
 def thanks_view(request):
     feedback = None
     suggestions = None
-    # FIXME: hard-coded product
-    product_slug = u'Firefox'
 
     response_id = None
     # If the user is an analyzer/admin, then we let them specify
@@ -98,13 +96,18 @@ def thanks_view(request):
             pass
 
     if feedback:
-        product_slug = feedback.product
+        product = Product.objects.get(db_name=feedback.product)
         suggestions = get_suggestions(feedback, request)
+    else:
+        # If there's no feedback, then we just show the thanks page as if it
+        # were for Firefox. This is a weird edge case that might happen if the
+        # user has cookies disabled or something like that.
+        product = Product.objects.get(db_name=u'Firefox')
 
-    template = get_config(product_slug)['thanks_template']
+    template = get_config(product.slug)['thanks_template']
 
     return render(request, template, {
-        'product': product_slug,
+        'product': product,
         'feedback': feedback,
         'suggestions': suggestions
     })


### PR DESCRIPTION
I goofed when I added support for product_config where the keys to
product slug were product slugs, but what we're storing in the
feedback_response table is the product db_name. Thus doing a lookup
using the product db_name would always fail. Oops!

This fixes that.