### PR TITLE
[bug 1129703] Switch gengo balance check to use mailing list

### DIFF
--- a/fjord/translations/migrations/0003_auto_20160105_0657.py
+++ b/fjord/translations/migrations/0003_auto_20160105_0657.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def add_gengo_balance(apps, schema_editor):
+    MailingList = apps.get_model('mailinglist', 'MailingList')
+    ml = MailingList.objects.create(name='gengo_balance')
+    ml.save()
+
+
+def remove_gengo_balance(apps, schema_editor):
+    MailingList = apps.get_model('mailinglist', 'MailingList')
+    MailingList.objects.filter(name='gengo_balance').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('translations', '0002_gengojob_tier'),
+        ('mailinglist', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_gengo_balance, remove_gengo_balance),
+    ]

--- a/fjord/translations/tests/test_gengo.py
+++ b/fjord/translations/tests/test_gengo.py
@@ -8,6 +8,7 @@ import requests_mock
 import pytest
 
 from fjord.base.tests import TestCase
+from fjord.mailinglist.models import MailingList
 from fjord.translations import gengo_utils
 from fjord.translations.models import (
     GengoHumanTranslator,
@@ -382,6 +383,11 @@ class TestHumanTranslation(BaseGengoTestCase):
     @account_balance(0.0)
     def test_push_translations_low_balance_mails_admin(self):
         """Tests that a low balance sends email and does nothing else"""
+        # Add recipients to mailing list
+        ml = MailingList.objects.get(name='gengo_balance')
+        ml.members = u'foo@example.com'
+        ml.save()
+
         # Verify nothing is in the outbox
         assert len(mail.outbox) == 0
 
@@ -460,6 +466,11 @@ class TestHumanTranslation(BaseGengoTestCase):
     )
     def test_gengo_push_translations_not_enough_balance(self):
         """Tests enough balance for one order, but not both"""
+        # Add recipients to mailing list
+        ml = MailingList.objects.get(name='gengo_balance')
+        ml.members = u'foo@example.com'
+        ml.save()
+
         ght = GengoHumanTranslator()
 
         # Create a few jobs covering multiple languages
@@ -548,6 +559,11 @@ class TestHumanTranslation(BaseGengoTestCase):
     )
     def test_gengo_daily_activities_warning(self):
         """Tests warning email is sent"""
+        # Add recipients to mailing list
+        ml = MailingList.objects.get(name='gengo_balance')
+        ml.members = u'foo@example.com'
+        ml.save()
+
         ght = GengoHumanTranslator()
 
         with patch('fjord.translations.gengo_utils.Gengo') as GengoMock:


### PR DESCRIPTION
This cleans up some code I wrote a while ago such that it now uses a
mailing list rather than mailing the admin when there are gengo
balance alerts.