### PR TITLE
[bug 1239017] Add URL pre-filling via URL

### DIFF
--- a/fjord/feedback/static/js/generic_feedback.js
+++ b/fjord/feedback/static/js/generic_feedback.js
@@ -160,5 +160,8 @@
                 selectHappySad(1);
             }
         }
+        if (qs.url) {
+            $('#id_url').val(qs.url).trigger('input');
+        }
     });
 }(jQuery, fjord, cards, remoteTroubleshooting, document, window));

--- a/smoketests/tests/generic/test_submit.py
+++ b/smoketests/tests/generic/test_submit.py
@@ -85,7 +85,8 @@ class TestSubmit(object):
 
         # 1. go to the feedback form with sad prefill
         feedback_pg = GenericFeedbackFormPage(mozwebqa)
-        feedback_pg.go_to_feedback_page('firefox', querystring='happy=0')
+        feedback_pg.go_to_feedback_page(
+            'firefox', querystring='happy=0&url=http%3A%2F%2Fwww.mozilla.org')
 
         # 2. fill out description
         feedback_pg.set_description(desc)
@@ -100,6 +101,7 @@ class TestSubmit(object):
         dashboard_pg.search_for(desc)
         resp = dashboard_pg.messages[0]
         assert resp.type.strip() == 'Sad'
+        assert resp.url.strip() == 'http://www.mozilla.org'
         assert resp.body.strip() == desc.strip()
         assert resp.locale.strip() == 'English (US)'
 


### PR DESCRIPTION
This allows you to create a URL that pre-fills the feedback URL.

    /feedback/?url=somewebsite.com