### PR TITLE
Bug 1235417: Switch to git for storing translations.

### DIFF
--- a/bin/update/update.py
+++ b/bin/update/update.py
@@ -36,21 +36,21 @@ def update_product_details(ctx):
 
 @task
 def update_locales(ctx):
-    """Update a locale directory from SVN.
+    """Update a locale directory from Git.
 
     Assumes localizations:
 
     1) exist,
-    2) are in SVN,
+    2) are in Git,
     3) are in SRC_DIR/locale, and
     4) have a compile-mo.sh script
 
     This should all be pretty standard, but change it if you need to.
 
     """
-    # Do an svn up to get the latest .po files.
+    # Do an git pull to get the latest .po files.
     with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
-        ctx.local('svn up')
+        ctx.local('git pull origin master')
 
     # Run the script that lints the .po files and compiles to .mo the
     # the ones that don't have egregious errors in them. This prints
@@ -121,8 +121,9 @@ def update_info(ctx):
         ctx.local('git submodule status')
         ctx.local(PYTHON + ' manage.py migrate --list')
         with ctx.lcd('locale'):
-            ctx.local('svn info')
-            ctx.local('svn status')
+            ctx.local('git branch')
+            ctx.local('git log -3')
+            ctx.local('git status')
 
         ctx.local('git rev-parse HEAD > media/revision.txt')
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -503,7 +503,7 @@ your Elasticsearch index, reindexing, getting status, deleting the
 index and debugging tools.
 
 :ref:`l10n-chapter` covers how we do localization in Fjord like links
-to the svn repository where .po files are stored, Verbatim links,
+to the git repository where .po files are stored, Verbatim links,
 getting localized strings, updating strings in Verbatim with new
 strings, testing strings with Dennis, linting strings, creating new
 locales, etc.

--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -15,23 +15,22 @@ Things to know about l10n
    in use
 
 3. the -dev environment should have a cronjob kicking off every 10
-   minutes that updates the svn locale repository so that translators
+   minutes that updates the git locale repository so that translators
    can see the latest stuff
 
-:svn url:    https://svn.mozilla.org/projects/l10n-misc/trunk/input/locale
-:viewvc svn: http://viewvc.svn.mozilla.org/vc/projects/l10n-misc/trunk/input/locale/
-:Verbatim:   https://localize.mozilla.org/projects/input/
+:git url:    https://github.com/mozilla-l10n/input-l10n
+:Pontoon:    https://pontoon.mozilla.org/projects/firefox-input/
 
 
-Installing localizations from svn
+Installing localizations from git
 =================================
 
 Localizations are not stored in this repository--they're in Mozilla's
-subversion repository.
+Git repository.
 
 To get the localizations, do::
 
-    svn checkout https://svn.mozilla.org/projects/l10n-misc/trunk/input/locale locale
+    git clone https://github.com/mozilla-l10n/input-l10n.git locale
 
 To see the translated strings, you need to first compile the .po files to
 .mo files::
@@ -43,17 +42,13 @@ settings file, ``./fjord/settings/local.py``.
 
 .. _l10n-update-strings:
 
-Extract/merge/sync strings with svn
+Extract/merge/sync strings with git
 ===================================
 
-First, ping Will or whoever else can sync strings with Verbatim and tell
-him/her we're merging strings (i.e. extracting them from our codebase and
-committing the changes to svn).
-
-Then, update the svn repository::
+First, update the git repository::
 
     cd locale
-    svn update
+    git pull origin master
     cd ..
 
 Then, extract the strings from the codebase::
@@ -62,17 +57,14 @@ Then, extract the strings from the codebase::
     ./manage.py extract
     ./manage.py merge
 
-Commit the db strings to the repo::
+Commit the db strings to the app repo::
 
     git commit -a
 
-Then, commit the new strings to svn::
+Then, commit the new strings to the string repo::
 
     cd locale
-    svn commit -m 'Input strings update YYYY/MM/DD'
-
-Then, tell him/her that the strings have been extracted. He/she will
-update Verbatim for all locales.
+    git commit -m 'Input strings update YYYY/MM/DD'
 
 .. Note::
 
@@ -83,9 +75,9 @@ After that, send an email to the `dev-l10n-web mailing list
 
     Hi!
 
-    I've just pushed new strings to Verbatim for Input.
+    I've just pushed new strings to Pontoon for Input.
 
-    https://localize.mozilla.org/projects/input/
+    https://pontoon.mozilla.org/projects/firefox-input/
 
     < explanation of strings changes here >
 
@@ -106,8 +98,7 @@ translations. It's nice to copy/paste the specific strings that need to be
 translated.
 
 Sometimes the translator says they've finished, but the string updates aren't
-in svn. If that happens, tell the translator that they have to push the
-"Commit to VCS" button/link.
+in git. If that happens, contact the Pontoon admin team.
 
 
 Creating new localization locales

--- a/docs/maintain.rst
+++ b/docs/maintain.rst
@@ -128,7 +128,7 @@ and so that people can see the site in that language and submit feedback:
       for better language because I only vaguely understand how the
       Verbatim side works.
 
-   Once the locale is in svn and ``locale/``, proceed.
+   Once the locale is in git and ``locale/``, proceed.
 
 4. Add the locale code to the ``PROD_LANGUAGES`` list in
    ``fjord/settings/base.py``.


### PR DESCRIPTION
I didn't touch `bin/update_site.py` because I assumed it was out-of-date as a deploy script, but I didn't want to just remove it. Maybe I should?

The process here is:
1. Merge this branch.
2. File a webops bug to replace the svn directory on staging with a git repo.
3. Once staging has the right directory, deploy this update.
4. Switch Pontoon's Input project over to the new git repo and test the entire process from submitting a Pontoon translation to deploying it to staging.
5. If things go well, repeat steps 2-4 on production.

@mythmon r?