### PR TITLE
Fix bug 1264916: Always pass a str to parse_qsl.

### DIFF
--- a/fjord/base/templatetags/jinja_helpers.py
+++ b/fjord/base/templatetags/jinja_helpers.py
@@ -38,7 +38,7 @@ def urlparams(url_, hash=None, **query):
 
     # Use dict(parse_qsl) so we don't get lists of values.
     q = url.query
-    query_dict = dict(urlparse.parse_qsl(smart_text(q))) if q else {}
+    query_dict = dict(urlparse.parse_qsl(smart_str(q))) if q else {}
     query_dict.update((k, v) for k, v in query.items())
 
     query_string = _urlencode([(k, v) for k, v in query_dict.items()

--- a/fjord/base/tests/test_helpers.py
+++ b/fjord/base/tests/test_helpers.py
@@ -1,4 +1,4 @@
-from fjord.base.templatetags.jinja_helpers import locale_name
+from fjord.base.templatetags.jinja_helpers import locale_name, urlparams
 from fjord.base.tests import TestCase
 
 
@@ -22,3 +22,11 @@ class TestLocaleName(TestCase):
         ]
         for name, expected in data:
             assert unicode(locale_name(name, native=True)) == expected
+
+
+class TestUrlParams(TestCase):
+    def test_utf8_urlencoded_query(self):
+        """urlparams should not modify urlencoded unicode."""
+        # %C3%B1 is urlencoded unicode.
+        url = u'http://example.com/foo.html?bar=%C3%B1'
+        assert urlparams(url, hash='biff') == url + u'#biff'


### PR DESCRIPTION
When a URL contains unicode, Django's request.get_full_path() returns
a unicode string with percent-encoded unicode strings. parse_qsl fails
to parse this properly, and returns a unicode string with bytes in it,
instead of codepoints. To fix this, we encode the URL in ASCII before
passing it to parse_qsl.

See http://www.lexev.org/en/2013/parse-url-which-chontains-unicode-query-using-urlp/ for a slightly more detailed description.

My local tests are borked so I'm hoping the automated tests will fare better. 

@mythmon r?