### PR TITLE
Fix requirement hashes.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,6 +46,7 @@ pytest==2.8.2
 pytest-django==2.9.1
 
 # sha256: w2yTiocuX_SUk4szsUqqFWy0OexnVI_Ks1Nbt4sIRug
+# sha256: Gbs6w1Dvh43ahKYtN8fVwXoTc4bd6cLOcknHoh1_ask
 pyyaml==3.11
 
 # sha256: IX5Hl9o6mkqfvmci4NuYBwuEQ6iCEtes29JBp2aBQdk

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 # Requirements that need to be updated first
 
 # sha256: L6IwcnEEsH5SLe7BeSnoTgQckEfjksBVNHoCsNXKh00
+# sha256: VgrecEvl0AC1Dic-Sj9uAnLztGVwPEign7Pd1eLTVjc
 setuptools==18.3.1
 
 # Requirements from github urls because we're using non-released things
@@ -124,6 +125,8 @@ GitPython==0.1.7
 html5lib==0.999999
 
 # sha256: fLtRSjUvghxpuOi9qmsuWXKFR6iWVQPHWGUsKCbRV7U
+# sha256: AfwKKh4BmQqXsJZhXBEyj6QwbO0XM8mNiEFgOHdg1Hk
+# sha256: ZfNCpgSi4QKHB8XgVSZqskMcJuIP4QeAtCMyCHCITaw
 importlib==1.0.3
 
 # sha256: H1ZavUTEt9-qTdVD1S-YLS8AaroKKzgwVCtNJagB_gk


### PR DESCRIPTION
PyPI is serving us zip files instead of tar.gz/tar.bz files, causing
peep to fail hash verification. I verified the hashes we had against
PyPI's tarballs, diffed their contents against the zipfiles to
ensure they hadn't changed, and then got the hashes of the zipfiles
and added them here.

See https://bitbucket.org/pypa/pypi/issues/436/peep-hash-failures-due-to-being-served-zip
for more info.